### PR TITLE
Hotfix: Change credentials for GHCR login in Cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,8 +21,8 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Setup backend using Docker Compose
         env:


### PR DESCRIPTION
Izgleda da trebaju drugi kredencijali da bi se povukli container-i iz drugog repozitorijuma. Prepravljeni su da budu tajne promjenljive na nivou repozitorijuma.

U podesavanjima ovog repo-a treba da se podese `GHCR_USER` i `GHCR_PAT` da bi login proradio. Javite se preko Discord-a da bih vam ih tamo poslao. 