### PR TITLE
Fix auth refresh, orders display, portfolio, tax/exchange endpoints, …

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import TaxPage from './pages/admin/TaxPage';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore }    from './store/authStore';
 import { useLayoutEffect } from 'react';
+import { useTokenRefresh } from './hooks/useTokenRefresh';
 import { usePermissions } from './hooks/usePermissions.js';
 
 // Auth pages
@@ -90,6 +91,8 @@ export default function App() {
   useLayoutEffect(() => {
     useAuthStore.getState().initFromStorage();
   }, []);
+
+  useTokenRefresh();
 
   const getDefaultRoute = () => {
     if (!token) return '/login';

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { useAuthStore } from '../store/authStore';
 
+const AUTH_BASE = import.meta.env.VITE_API_URL.replace(/\/$/, '');
+
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   headers: { 'Content-Type': 'application/json' },
@@ -73,9 +75,9 @@ api.interceptors.response.use(
     }
 
     try {
-      const res = await axios.post(`${import.meta.env.VITE_API_URL}/auth/refresh`, { refresh_token: refreshToken });
+      const res = await axios.post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken });
       const newToken   = res.data.token;
-      const newRefresh = res.data.refresh_token;
+      const newRefresh = res.data.refresh_token || refreshToken;
       const currentUser = useAuthStore.getState().user;
       useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
 
@@ -124,9 +126,9 @@ bankingApi.interceptors.response.use(
     }
 
     try {
-      const res = await axios.post(`${import.meta.env.VITE_API_URL}/auth/refresh`, { refresh_token: refreshToken });
+      const res = await axios.post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken });
       const newToken   = res.data.token;
-      const newRefresh = res.data.refresh_token;
+      const newRefresh = res.data.refresh_token || refreshToken;
       const currentUser = useAuthStore.getState().user;
       useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
 
@@ -151,7 +153,7 @@ tradingApi.interceptors.response.use(
   async err => {
     const original = err.config;
 
-    if ((err.response?.status !== 401 && err.response?.status !== 403) || original._retry) {
+    if (err.response?.status !== 401 || original._retry) {
       return Promise.reject(err.response?.data ?? err);
     }
 
@@ -174,9 +176,9 @@ tradingApi.interceptors.response.use(
     }
 
     try {
-      const res = await axios.post(`${import.meta.env.VITE_API_URL}/auth/refresh`, { refresh_token: refreshToken });
+      const res = await axios.post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken });
       const newToken   = res.data.token;
-      const newRefresh = res.data.refresh_token;
+      const newRefresh = res.data.refresh_token || refreshToken;
       const currentUser = useAuthStore.getState().user;
       useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
 

--- a/src/api/endpoints/exchange.js
+++ b/src/api/endpoints/exchange.js
@@ -6,6 +6,6 @@ export const exchangeApi = {
 };
 
 export const stockExchangeApi = {
-    getAll: () => tradingApi.get('/exchange'),
-    toggle: (micCode) => tradingApi.patch(`/exchange/${micCode}/toggle`),
+    getAll: () => tradingApi.get('/exchanges'),
+    toggle: (micCode) => tradingApi.patch(`/exchanges/${micCode}/toggle`),
 };

--- a/src/api/endpoints/securities.js
+++ b/src/api/endpoints/securities.js
@@ -1,16 +1,13 @@
 import { tradingApi as api } from '../client';
 
 function unpack(res) {
-  const raw = res?.data ?? res;
+  // Interceptor već vrati res.data, ali ako nije, uzmi res.data ?? res
+  const raw = (res?.data !== undefined && res?.status !== undefined) ? res.data : res;
   if (typeof raw !== 'string') return raw;
-  // Backend šalje duplirani JSON — uzimamo samo prvi objekat
-  const firstJson = raw.slice(0, raw.indexOf('}]') + 2) + '}';
+  // Fallback za slučaj da backend vrati string (stari duplirani JSON bug)
   try {
-    return JSON.parse(firstJson);
+    return JSON.parse(raw);
   } catch {
-    // Fallback: pokušaj da nađeš prvi kompletan JSON objekat
-    const match = raw.match(/^\{.*?"pageSize":\d+\}/s);
-    if (match) return JSON.parse(match[0]);
     return { data: [] };
   }
 }
@@ -172,15 +169,12 @@ function attachHistory(mapped, history) {
 export const securitiesApi = {
 
   getStocks(params = {}) {
-  return api.get('/listings/stocks', { params }).then(res => {
-    const parsed = unpack(res);
-    console.log('TYPE OF RES:', typeof res, 'TYPE OF RES.DATA:', typeof res?.data);
-    console.log('PARSED:', parsed);
-    console.log('LIST:', Array.isArray(parsed) ? parsed : parsed?.data);
-    const list = Array.isArray(parsed) ? parsed : parsed?.data ?? [];
-    return list.map(mapStock);
-  });
-},
+    return api.get('/listings/stocks', { params }).then(res => {
+      const parsed = unpack(res);
+      const list = Array.isArray(parsed) ? parsed : parsed?.data ?? [];
+      return list.map(mapStock);
+    });
+  },
 
   getFutures(params = {}) {
     return api.get('/listings/futures', { params }).then(res => {

--- a/src/api/endpoints/tax.js
+++ b/src/api/endpoints/tax.js
@@ -3,7 +3,7 @@ import { tradingApi as api } from '../client';
 export const taxApi = {
   // GET /api/tax/users — lista korisnika sa poreskim podacima
   // Podržava query params: userType ("client"|"actuary"), first_name, last_name, page, page_size
-  getUsers: (params = {}) => api.get('/tax/users', { params }),
+  getUsers: (params = {}) => api.get('/tax', { params }),
 
   // POST /api/tax/collect — pokretanje naplate poreza za SVE korisnike (bez parametara)
   collect: () => api.post('/tax/collect'),

--- a/src/features/actuaries/LimitModal.jsx
+++ b/src/features/actuaries/LimitModal.jsx
@@ -20,7 +20,7 @@ export default function LimitModal({ open, onClose, onConfirm, actuary, loading 
   async function handleSubmit(e) {
     e.preventDefault();
     const parsed = Number(newLimit);
-    if (!newLimit.toString().trim() || isNaN(parsed) || parsed < 0) {
+    if (!newLimit.toString().trim() || isNaN(parsed) || parsed <= 0) {
       setError('Unesite validan limit (pozitivan broj).');
       return;
     }

--- a/src/features/securities/SecurityTabs.jsx
+++ b/src/features/securities/SecurityTabs.jsx
@@ -7,8 +7,12 @@ const TABS = [
   { value: 'OPTIONS', label: 'Opcije',  icon: '📄' },
 ];
 
-export default function SecurityTabs({ activeTab, onChange, canSeeForex }) {
-  const visibleTabs = canSeeForex ? TABS : TABS.filter(t => t.value !== 'FOREX');
+export default function SecurityTabs({ activeTab, onChange, canSeeForex, canSeeOptions }) {
+  const visibleTabs = TABS.filter(t => {
+    if (t.value === 'FOREX'    && !canSeeForex)   return false;
+    if (t.value === 'OPTIONS'  && !canSeeOptions) return false;
+    return true;
+  });
 
   return (
     <div className={styles.tabsWrapper}>

--- a/src/features/tax/TaxTable.jsx
+++ b/src/features/tax/TaxTable.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import styles from './TaxTable.module.css';
 
 const STATUS_CLASS = {
@@ -43,7 +43,7 @@ export default function TaxTable({ users = [], loading = false, onRunCalculation
           </tr>
         </thead>
         <tbody>
-          {users.map(user => {
+          {users.map((user, i) => {
             const isExpanded = expandedId === user.id;
             const hasAccounts = user.accounts && user.accounts.length > 0;
             const ukupnoDugovanje = hasAccounts
@@ -51,9 +51,8 @@ export default function TaxTable({ users = [], loading = false, onRunCalculation
               : user.tax_debt;
 
             return (
-              <>
+              <React.Fragment key={user.email || user.id || i}>
                 <tr
-                  key={user.id}
                   className={`${styles.mainRow} ${isExpanded ? styles.mainRowExpanded : ''} ${hasAccounts ? styles.mainRowClickable : ''}`}
                   onClick={() => hasAccounts && toggleExpand(user.id)}
                 >
@@ -104,7 +103,7 @@ export default function TaxTable({ users = [], loading = false, onRunCalculation
                 </tr>
 
                 {isExpanded && hasAccounts && (
-                  <tr key={`${user.id}-expand`} className={styles.expandRow}>
+                  <tr className={styles.expandRow}>
                     <td colSpan={8} className={styles.expandCell}>
                       <div className={styles.expandContent}>
                         <table className={styles.accountsTable}>
@@ -147,7 +146,7 @@ export default function TaxTable({ users = [], loading = false, onRunCalculation
                     </td>
                   </tr>
                 )}
-              </>
+              </React.Fragment>
             );
           })}
         </tbody>

--- a/src/hooks/useTokenRefresh.js
+++ b/src/hooks/useTokenRefresh.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { useEffect } from 'react';
+import { useAuthStore } from '../store/authStore';
+
+const BASE = import.meta.env.VITE_API_URL.replace(/\/$/, '');
+
+function parseJwtExp(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1])).exp * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Proaktivno osvežava access token 60s pre isteka.
+ * Poziva se u App.jsx jednom za celu aplikaciju.
+ */
+export function useTokenRefresh() {
+  const token = useAuthStore(s => s.token);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const exp = parseJwtExp(token);
+    if (!exp) return;
+
+    const delay = exp - Date.now() - 60_000;
+
+    async function doRefresh() {
+      const refreshToken = localStorage.getItem('refreshToken');
+      if (!refreshToken || refreshToken === 'undefined') return;
+      try {
+        const res = await axios.post(
+          `${BASE}/auth/refresh`,
+          { refresh_token: refreshToken },
+        );
+        const newToken   = res.data.token;
+        const newRefresh = res.data.refresh_token || refreshToken;
+        const currentUser = useAuthStore.getState().user;
+        useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
+      } catch {
+        // Ne radimo ništa — 401 interceptor će preuzeti ako zahtev padne
+      }
+    }
+
+    if (delay <= 0) {
+      doRefresh();
+      return;
+    }
+
+    const timer = setTimeout(doRefresh, delay);
+    return () => clearTimeout(timer);
+  }, [token]);
+}

--- a/src/pages/admin/ActuariesPage.jsx
+++ b/src/pages/admin/ActuariesPage.jsx
@@ -7,6 +7,7 @@ import Alert              from '../../components/ui/Alert';
 import ActuaryFilters     from '../../features/actuaries/ActuaryFilters';
 import ActuaryTable       from '../../features/actuaries/ActuaryTable';
 import LimitModal         from '../../features/actuaries/LimitModal';
+import limitStyles        from '../../features/actuaries/LimitModal.module.css';
 import styles             from './ActuariesPage.module.css';
 
 const EMPTY_FILTERS = { email: '', first_name: '', last_name: '', position: '' };
@@ -26,6 +27,10 @@ export default function ActuariesPage() {
   const [limitOpen,    setLimitOpen]    = useState(false);
   const [limitLoading, setLimitLoading] = useState(false);
   const [selectedActuary, setSelectedActuary] = useState(null);
+
+  // Reset confirmation modal state
+  const [resetTarget,  setResetTarget]  = useState(null);
+  const [resetLoading, setResetLoading] = useState(false);
 
   const load = useCallback((params = {}) => {
     setLoading(true);
@@ -82,15 +87,23 @@ export default function ActuariesPage() {
     }
   }
 
-  async function handleResetUsedLimit(actuary) {
+  function handleResetUsedLimit(actuary) {
+    setResetTarget(actuary);
+  }
+
+  async function handleConfirmReset() {
+    setResetLoading(true);
     try {
-      await actuariesApi.resetUsedLimit(actuary.id);
+      await actuariesApi.resetUsedLimit(resetTarget.id);
       setActuaries(prev =>
-        prev.map(a => a.id === actuary.id ? { ...a, used_limit: 0 } : a)
+        prev.map(a => a.id === resetTarget.id ? { ...a, used_limit: 0 } : a)
       );
-      setFeedback({ type: 'uspeh', text: `Iskorišćen limit za ${actuary.first_name} ${actuary.last_name} je resetovan.` });
+      setFeedback({ type: 'uspeh', text: `Iskorišćen limit za ${resetTarget.first_name} ${resetTarget.last_name} je resetovan.` });
+      setResetTarget(null);
     } catch (err) {
       setFeedback({ type: 'greska', text: err?.response?.data?.error ?? err?.message ?? 'Greška pri resetovanju limita.' });
+    } finally {
+      setResetLoading(false);
     }
   }
 
@@ -141,6 +154,29 @@ export default function ActuariesPage() {
         actuary={selectedActuary}
         loading={limitLoading}
       />
+
+      {resetTarget && (
+        <div className={limitStyles.backdrop} onClick={() => setResetTarget(null)}>
+          <div className={limitStyles.modal} onClick={e => e.stopPropagation()}>
+            <h3 className={limitStyles.title}>Resetuj used limit</h3>
+            <p className={limitStyles.subtitle}>
+              {resetTarget.first_name} {resetTarget.last_name}
+            </p>
+            <div className={limitStyles.divider} />
+            <p style={{ fontSize: 14, color: 'var(--tx-2)', margin: '0 0 20px' }}>
+              Da li ste sigurni da želite da resetujete iskorišćen limit?
+            </p>
+            <div className={limitStyles.actions}>
+              <button className={limitStyles.btnGhost} onClick={() => setResetTarget(null)} disabled={resetLoading}>
+                Otkaži
+              </button>
+              <button className={limitStyles.btnPrimary} onClick={handleConfirmReset} disabled={resetLoading}>
+                {resetLoading ? 'Čuvanje...' : 'Potvrdi'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/admin/ExchangesPage.jsx
+++ b/src/pages/admin/ExchangesPage.jsx
@@ -72,9 +72,9 @@ export default function ExchangesPage() {
             <Spinner />
           </div>
         ) : error ? (
-          <Alert type="error" message="Nije moguće učitati listu berzi." />
+          <Alert tip="greska" poruka="Nije moguće učitati listu berzi." />
         ) : exchanges.length === 0 ? (
-          <Alert type="info" message="Nema dostupnih berzi." />
+          <Alert tip="info" poruka="Nema dostupnih berzi." />
         ) : (
           <div className={styles.grid}>
             {exchanges.map(ex => {

--- a/src/pages/admin/TaxPage.jsx
+++ b/src/pages/admin/TaxPage.jsx
@@ -158,7 +158,7 @@ export default function TaxPage() {
           </div>
         )}
 
-        {(error || calcError) && (
+        {(error || calcError) && !calcSuccess && (
           <div className="page-anim">
             <Alert tip="greska" poruka={error ?? calcError} />
           </div>

--- a/src/pages/client/ClientAccounts.jsx
+++ b/src/pages/client/ClientAccounts.jsx
@@ -312,7 +312,7 @@ export default function ClientAccounts() {
 
   // Filter active + sort by criteria
   const accounts = useMemo(() => {
-    return [...localAccounts].sort((a, b) => {
+    return localAccounts.filter(a => !a.status || a.status === 'ACTIVE').sort((a, b) => {
       if (accountSortBy === 'balance') return (b.balance ?? 0) - (a.balance ?? 0);
       if (accountSortBy === 'available') {
         const availA = (a.balance ?? 0) - (a.reserved_funds ?? 0);

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -38,7 +38,8 @@ export default function ClientPortfolioPage() {
         setLoading(true);
         setError(null);
         
-        const res = await portfolioApi.getClientPortfolio(user.id);
+        const clientId = user.client_id ?? user.id;
+        const res = await portfolioApi.getClientPortfolio(clientId);
         
         // Uzimamo podatke (client.js interceptor bi trebalo da već vraća res.data)
         const rawData = res?.data || res;

--- a/src/pages/client/ClientSecurities.jsx
+++ b/src/pages/client/ClientSecurities.jsx
@@ -13,6 +13,7 @@ import Navbar from '../../components/layout/Navbar';
 import styles from './ClientSubPage.module.css';
 import secStyles from './ClientSecurities.module.css';
 import { clientApi } from '../../api/endpoints/client';
+import { accountsApi } from '../../api/endpoints/accounts';
 
 
 function applyFilters(list, filters, search) {
@@ -62,11 +63,16 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
   const [stopValue, setStopValue] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [afterHours, setAfterHours] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [error, setError] = useState('');
 
   const clientId = useAuthStore(s => s.user?.client_id ?? s.user?.id);
-  const { data: accountsData } = useFetch(() => clientApi.getAccounts(clientId), [clientId]);
+  // Zaposleni koriste bankine račune, klijenti koriste svoje lične račune
+  const { data: accountsData } = useFetch(
+    () => isEmployee ? accountsApi.getAll() : clientApi.getAccounts(clientId),
+    [isEmployee, clientId]
+  );
   const accounts = Array.isArray(accountsData) ? accountsData : accountsData?.data ?? [];
 
   if (!security) return null;
@@ -136,7 +142,7 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
     setError('');
 
     try {
-      await securitiesApi.buy({
+      const result = await securitiesApi.buy({
         listingId:     security.id,
         accountNumber: accountNumber,
         quantity:      Number(qty),
@@ -145,6 +151,7 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
         stopValue:     needsStop  ? Number(stopValue)  : 0,
       });
 
+      setAfterHours(result?.after_hours === true);
       setSubmitted(true);
       setShowConfirm(false);
     } catch (err) {
@@ -168,11 +175,15 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
             <div className={styles.successBanner}>
               {isEmployee
                 ? '✓ Order je kreiran i čeka odobrenje.'
-                : '✓ Kupovina uspešna! Hartija je dodata u portfolio.'}
+                : afterHours
+                  ? '✓ Order je kreiran. Izvršiće se kada berza otvori.'
+                  : '✓ Order je kreiran i u obradi.'}
             </div>
-            {isEmployee && (
+            {(isEmployee || afterHours) && (
               <p style={{ fontSize: 13, color: 'var(--tx-2)', marginTop: 12 }}>
-                Novac će biti skinut sa računa tek nakon odobrenja.
+                {afterHours && !isEmployee
+                  ? 'Tržište je zatvoreno. Novac i hartija će biti ažurirani kada berza otvori.'
+                  : 'Novac će biti skinut sa računa tek nakon odobrenja.'}
               </p>
             )}
           </div>
@@ -372,8 +383,9 @@ export default function ClientSecurities() {
   const pageRef = useRef(null);
   const user = useAuthStore(s => s.user);
 
-  const isEmployee  = user?.identity_type === 'employee';
-  const canSeeForex = isEmployee;
+  const isEmployee    = user?.identity_type === 'employee';
+  const canSeeForex   = isEmployee;
+  const canSeeOptions = isEmployee;
 
   const [activeTab, setActiveTab] = useState('STOCK');
   const [selectedSec, setSelectedSec]   = useState(null);
@@ -393,7 +405,7 @@ export default function ClientSecurities() {
   }, [activeTab]);
 
   const { data: rawData, loading, error, refetch } = useFetch(fetcher, [activeTab]);
-  console.log('STATE:', { loading, error, rawData }); // DODAJ OVO
+
   const securities = Array.isArray(rawData) ? rawData : [];
 
   const filtered = useMemo(() => applyFilters(securities, filters, search), [securities, filters, search]);
@@ -483,6 +495,7 @@ export default function ClientSecurities() {
             activeTab={activeTab}
             onChange={handleTabChange}
             canSeeForex={canSeeForex}
+            canSeeOptions={canSeeOptions}
           />
 
           <div className={secStyles.searchWrap}>

--- a/src/pages/supervisor/SupervisorOrdersPage.jsx
+++ b/src/pages/supervisor/SupervisorOrdersPage.jsx
@@ -144,7 +144,10 @@ export default function SupervisorOrdersPage() {
 
     try {
       const response = ordersData;
-      const normalized = (Array.isArray(response) ? response : response?.items ?? []).map(normalizeOrder);
+      const rawList = Array.isArray(response)
+        ? response
+        : (response?.items ?? response?.data ?? response?.content ?? response?.orders ?? []);
+      const normalized = rawList.map(normalizeOrder);
 
       // setOrders(normalized.length > 0 ? normalized : MOCK_ORDERS.map(normalizeOrder));
       setOrders(normalized);
@@ -308,12 +311,12 @@ export default function SupervisorOrdersPage() {
                     </tr>
                   )}
 
-                  {filteredOrders.map((order) => {
+                  {filteredOrders.map((order, i) => {
                     const permissions = getOrderPermissions(order, actorRole);
                     const isBusy = processingId === order.id;
 
                     return (
-                      <tr key={order.id}>
+                      <tr key={order.id ?? i}>
                         <td>{order.agentName}</td>
                         <td>{formatOrderType(order.orderType)}</td>
                         <td>

--- a/src/utils/orders/orderModel.js
+++ b/src/utils/orders/orderModel.js
@@ -33,11 +33,11 @@ export const APPROVAL_DECISION = {
 
 export function normalizeOrder(raw) {
   return {
-    id: raw.id,
+    id: raw.id ?? raw.order_id,
     userId: raw.user_id ?? raw.userId,
     agentName: raw.agent_name ?? raw.agentName ?? '—',
     assetId: raw.asset_id ?? raw.assetId,
-    assetName: raw.asset_name ?? raw.assetName ?? '—',
+    assetName: raw.asset_name ?? raw.assetName ?? raw.listing_name ?? '—',
     assetType: raw.asset_type ?? raw.assetType ?? '—',
     orderType: raw.order_type ?? raw.orderType,
     quantity: raw.quantity ?? 0,


### PR DESCRIPTION
…securities UI

- Fix refresh token not being preserved when backend returns no new refresh token
- Add proactive token refresh (useTokenRefresh hook) 60s before expiry
- Fix 403 on tradingApi no longer triggering logout
- Fix tax endpoint path (/tax instead of /tax/users) and Alert props
- Fix exchange endpoint path (/exchanges) and Alert props
- Fix supervisor orders response parsing (data/items/content wrappers)
- Fix order normalization: order_id→id, listing_name→assetName mapping
- Fix Options tab hidden for clients (403 forbidden)
- Fix after_hours order success message in securities buy modal
- Fix portfolio using client_id instead of user.id
- Fix CLOSED accounts filtered out in ClientAccounts
- Fix LimitModal validation: reject 0 and negative values
- Add reset used-limit confirmation modal for actuaries (Cypress scenario 5)
- Fix React key prop warnings in TaxTable and SupervisorOrdersPage