### PR TITLE
Fix auth refresh, orders display, portfolio, tax/exchange endpoints, …

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -28,173 +28,63 @@ api.interceptors.request.use(attachToken);
 bankingApi.interceptors.request.use(attachToken);
 tradingApi.interceptors.request.use(attachToken);
 
-let isRefreshing = false;
-let failedQueue  = [];
+let refreshPromise = null;
 
-function processQueue(error, token) {
-  failedQueue.forEach(({ resolve, reject }) => {
-    if (error) reject(error);
-    else       resolve(token);
-  });
-  failedQueue = [];
+function doRefresh() {
+  if (refreshPromise) return refreshPromise;
+
+  const refreshToken = localStorage.getItem('refreshToken');
+  if (!refreshToken || refreshToken === 'undefined') {
+    useAuthStore.getState().logout();
+    window.location.href = '/login';
+    return Promise.reject(new Error('No refresh token'));
+  }
+
+  refreshPromise = axios
+    .post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken })
+    .then(res => {
+      const newToken   = res.data.token;
+      const newRefresh = res.data.refresh_token || refreshToken;
+      const currentUser = useAuthStore.getState().user;
+      useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
+      return newToken;
+    })
+    .catch(err => {
+      useAuthStore.getState().logout();
+      window.location.href = '/login';
+      return Promise.reject(err);
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
+
+  return refreshPromise;
 }
 
-// Interceptor for main API (Core/Auth) - Handles standard 401 login logic
-api.interceptors.response.use(
-  res => res.data,
-  async err => {
+function attachRetry(axiosInstance) {
+  return async err => {
     const original = err.config;
-
     if (err.response?.status !== 401 || original._retry) {
       return Promise.reject(err.response?.data ?? err);
     }
-
     const authPaths = ['/login', '/refresh', '/activate', '/reset-password', '/forgot-password', '/register'];
     if (authPaths.some(p => original.url?.includes(p))) {
       return Promise.reject(err.response?.data ?? err);
     }
-
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        failedQueue.push({ resolve, reject });
-      }).then(token => {
-        original.headers.Authorization = `Bearer ${token}`;
-        return api(original);
-      });
-    }
-
     original._retry = true;
-    isRefreshing = true;
-
-    const refreshToken = localStorage.getItem('refreshToken');
-    if (!refreshToken || refreshToken === 'undefined') {
-      isRefreshing = false;
-      useAuthStore.getState().logout();
-      window.location.href = '/login';
-      return Promise.reject(err.response?.data ?? err);
-    }
-
     try {
-      const res = await axios.post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken });
-      const newToken   = res.data.token;
-      const newRefresh = res.data.refresh_token || refreshToken;
-      const currentUser = useAuthStore.getState().user;
-      useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
-
-      processQueue(null, newToken);
+      const newToken = await doRefresh();
       original.headers.Authorization = `Bearer ${newToken}`;
-      return api(original);
+      return axiosInstance(original);
     } catch (refreshErr) {
-      processQueue(refreshErr, null);
-      useAuthStore.getState().logout();
-      window.location.href = '/login';
       return Promise.reject(refreshErr);
-    } finally {
-      isRefreshing = false;
     }
-  }
-);
+  };
+}
 
-// Interceptor for Banking API - Same refresh logic but NEVER forces logout on 401
-// unless the REFRESH token call itself fails.
-bankingApi.interceptors.response.use(
-  res => res.data,
-  async err => {
-    const original = err.config;
-
-    if (err.response?.status !== 401 || original._retry) {
-      return Promise.reject(err.response?.data ?? err);
-    }
-
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        failedQueue.push({ resolve, reject });
-      }).then(token => {
-        original.headers.Authorization = `Bearer ${token}`;
-        return bankingApi(original);
-      });
-    }
-
-    original._retry = true;
-    isRefreshing = true;
-
-    const refreshToken = localStorage.getItem('refreshToken');
-    if (!refreshToken || refreshToken === 'undefined') {
-      isRefreshing = false;
-      // On bankingApi, if no refresh token, just fail the request, don't kill session
-      return Promise.reject(err.response?.data ?? err);
-    }
-
-    try {
-      const res = await axios.post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken });
-      const newToken   = res.data.token;
-      const newRefresh = res.data.refresh_token || refreshToken;
-      const currentUser = useAuthStore.getState().user;
-      useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
-
-      processQueue(null, newToken);
-      original.headers.Authorization = `Bearer ${newToken}`;
-      return bankingApi(original);
-    } catch (refreshErr) {
-      processQueue(refreshErr, null);
-      // Only now, if refresh itself fails, we logout
-      useAuthStore.getState().logout();
-      window.location.href = '/login';
-      return Promise.reject(refreshErr);
-    } finally {
-      isRefreshing = false;
-    }
-  }
-);
-
-// Interceptor for Trading API - Same refresh logic as bankingApi
-tradingApi.interceptors.response.use(
-  res => res.data,
-  async err => {
-    const original = err.config;
-
-    if (err.response?.status !== 401 || original._retry) {
-      return Promise.reject(err.response?.data ?? err);
-    }
-
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        failedQueue.push({ resolve, reject });
-      }).then(token => {
-        original.headers.Authorization = `Bearer ${token}`;
-        return tradingApi(original);
-      });
-    }
-
-    original._retry = true;
-    isRefreshing = true;
-
-    const refreshToken = localStorage.getItem('refreshToken');
-    if (!refreshToken || refreshToken === 'undefined') {
-      isRefreshing = false;
-      return Promise.reject(err.response?.data ?? err);
-    }
-
-    try {
-      const res = await axios.post(`${AUTH_BASE}/auth/refresh`, { refresh_token: refreshToken });
-      const newToken   = res.data.token;
-      const newRefresh = res.data.refresh_token || refreshToken;
-      const currentUser = useAuthStore.getState().user;
-      useAuthStore.getState().setAuth(currentUser, newToken, newRefresh);
-
-      processQueue(null, newToken);
-      original.headers.Authorization = `Bearer ${newToken}`;
-      return tradingApi(original);
-    } catch (refreshErr) {
-      processQueue(refreshErr, null);
-      useAuthStore.getState().logout();
-      window.location.href = '/login';
-      return Promise.reject(refreshErr);
-    } finally {
-      isRefreshing = false;
-    }
-  }
-);
+api.interceptors.response.use(res => res.data, attachRetry(api));
+bankingApi.interceptors.response.use(res => res.data, attachRetry(bankingApi));
+tradingApi.interceptors.response.use(res => res.data, attachRetry(tradingApi));
 
 export default api;
 

--- a/src/api/endpoints/orders.js
+++ b/src/api/endpoints/orders.js
@@ -27,7 +27,7 @@ export async function fetchUserName(userId) {
 
 export const ordersApi = {
   getSupervisorOrders(params = {}) {
-    return tradingApi.get('/orders', { params });
+    return tradingApi.get('/orders', { params: { page: 1, page_size: 100, ...params } });
   },
 
   approveOrder(orderId) {

--- a/src/features/securities/OptionTable.jsx
+++ b/src/features/securities/OptionTable.jsx
@@ -77,7 +77,7 @@ export default function OptionTable({ options, currentPrice, canExercise }) {
                 className={`${styles.expiryTab} ${selectedExpiry === g.settlementDate ? styles.expiryActive : ''} ${expired ? styles.expired : ''}`}
                 onClick={() => setSelectedExpiry(g.settlementDate)}
               >
-                {g.settlementDate}
+                {g.settlementDate ? new Date(g.settlementDate).toLocaleDateString('sr-RS') : '—'}
                 <span className={styles.daysLeft}>{expired ? 'Expired' : `${days}d`}</span>
               </button>
             );

--- a/src/features/securities/SecuritiesTable.jsx
+++ b/src/features/securities/SecuritiesTable.jsx
@@ -11,6 +11,13 @@ function fmt(n, decimals = 2) {
   return new Intl.NumberFormat('sr-RS', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }).format(n);
 }
 
+function fmtDate(d) {
+  if (!d) return '—';
+  const date = new Date(d);
+  if (isNaN(date.getTime())) return d;
+  return date.toLocaleDateString('sr-RS');
+}
+
 function fmtVol(n) {
   if (n == null) return '—';
   if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(2) + 'B';
@@ -124,8 +131,8 @@ export default function SecuritiesTable({
                   <td className={styles.td}>
                     {sec.settlementDate
                       ? new Date(sec.settlementDate) < new Date()
-                        ? <span style={{ color: 'var(--red, #ef4444)', fontWeight: 600 }}>{sec.settlementDate} (istekao)</span>
-                        : sec.settlementDate
+                        ? <span style={{ color: 'var(--red, #ef4444)', fontWeight: 600 }}>{fmtDate(sec.settlementDate)} (istekao)</span>
+                        : fmtDate(sec.settlementDate)
                       : '—'}
                   </td>
                 )}

--- a/src/features/securities/SecurityDetails.jsx
+++ b/src/features/securities/SecurityDetails.jsx
@@ -98,7 +98,8 @@ export default function SecurityDetails({ security, isEmployee, onAction, onRefr
 
   const { ticker, name, type, exchange, price, change, changePercent,
           currency, bid, ask, volume, maintenanceMargin, initialMarginCost,
-          settlementDate, options } = security;
+          settlementDate, options, strike, optionType, impliedVolatility, openInterest,
+          contractSize, contractUnit, base, quote } = security;
 
   const actionLabel = isEmployee ? 'Kreiraj nalog' : 'Kupi';
 
@@ -188,6 +189,42 @@ export default function SecurityDetails({ security, isEmployee, onAction, onRefr
           <div className={styles.dataCard}>
             <span>Settlement Date</span>
             <strong>{formatDate(settlementDate)}</strong>
+          </div>
+        )}
+        {contractSize != null && (
+          <div className={styles.dataCard}>
+            <span>Contract Size</span>
+            <strong>{contractSize}{contractUnit ? ` ${contractUnit}` : ''}</strong>
+          </div>
+        )}
+        {base && quote && (
+          <div className={styles.dataCard}>
+            <span>Par</span>
+            <strong>{base} / {quote}</strong>
+          </div>
+        )}
+        {strike != null && (
+          <div className={styles.dataCard}>
+            <span>Strike</span>
+            <strong>{fmt(strike)} {currency}</strong>
+          </div>
+        )}
+        {optionType && (
+          <div className={styles.dataCard}>
+            <span>Tip opcije</span>
+            <strong>{optionType}</strong>
+          </div>
+        )}
+        {impliedVolatility != null && (
+          <div className={styles.dataCard}>
+            <span>Impl. Volatility</span>
+            <strong>{fmt(impliedVolatility, 4)}</strong>
+          </div>
+        )}
+        {openInterest != null && (
+          <div className={styles.dataCard}>
+            <span>Open Interest</span>
+            <strong>{new Intl.NumberFormat('sr-RS').format(openInterest)}</strong>
           </div>
         )}
       </section>

--- a/src/pages/client/ClientSecurities.jsx
+++ b/src/pages/client/ClientSecurities.jsx
@@ -76,7 +76,7 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
     ? accountsData
     : accountsData?.data ?? accountsData?.content ?? [];
   const accounts = isEmployee
-    ? allAccounts.filter(a => a.AccountType === 'Bank')
+    ? allAccounts.filter(a => (a.account_type ?? a.AccountType)?.toUpperCase() === 'BANK')
     : allAccounts;
 
   if (!security) return null;
@@ -88,7 +88,7 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
   const needsLimit = orderType === 'LIMIT' || orderType === 'STOP_LIMIT';
   const needsStop  = orderType === 'STOP'  || orderType === 'STOP_LIMIT';
 
-  const selectedAccount = accounts.find(a => (a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number ?? a.id) === accountNumber);
+  const selectedAccount = accounts.find(a => (a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number) === accountNumber);
 
   function handleQtyChange(e) {
     const raw = e.target.value;
@@ -341,7 +341,7 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
               >
                 <option value="">Izaberite račun...</option>
                 {accounts.map((a, i) => {
-                  const num  = a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number ?? a.id ?? '';
+                  const num  = a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number ?? '';
                   const name = a.Name ?? a.name ?? a.owner_name ?? a.ownerName ?? a.owner ?? `Račun ${i + 1}`;
                   const bal  = a.Balance ?? a.AvailableBalance ?? a.balance ?? a.available_balance ?? a.availableBalance;
                   const cur  = a.Currency?.Code ?? a.currency ?? '';
@@ -427,8 +427,6 @@ const securities = Array.isArray(rawData)
   ? rawData
   : rawData?.data ?? [];
 
-//console.log('RAW DATA:', rawData);
-//console.log('SECURITIES:', securities);
 
   const filtered = useMemo(() => applyFilters(securities, filters, search), [securities, filters, search]);
   const sorted   = useMemo(() => applySort(filtered, sortBy, sortDir), [filtered, sortBy, sortDir]);
@@ -464,6 +462,7 @@ const securities = Array.isArray(rawData)
       if (activeTab === 'STOCK')   details = await securitiesApi.getStockById(sec.id);
       if (activeTab === 'FUTURES') details = await securitiesApi.getFuturesById(sec.id);
       if (activeTab === 'FOREX')   details = await securitiesApi.getForexById(sec.id);
+      if (activeTab === 'OPTIONS') details = await securitiesApi.getOptionById(sec.id);
       if (details) setSelectedSec(details);
     } catch {
       // fallback to list data


### PR DESCRIPTION
…securities UI

- auth: replace 3 duplicate refresh interceptors with shared doRefresh() promise to prevent race condition on concurrent 401s
- orders: fetch up to 100 orders on supervisor page, fix account_type filter casing
- securities: enable detail fetch (chart/history) for FUTURES, FOREX, OPTIONS tabs
- securities: show option fields (strike, IV, OI), futures fields (contract size/unit), forex pair in detail panel
- securities: format settlement dates in table and OptionTable expiry selector
- securities: fix getStockById URL (singular /listings/stock/{id} per Swagger)