### PR TITLE
Fix account selection for employee and client order flows

### DIFF
--- a/src/api/endpoints/accounts.js
+++ b/src/api/endpoints/accounts.js
@@ -4,16 +4,30 @@ export const accountsApi = {
   // Employee: list all accounts (paginated, filterable)
   getAll: (params) => bankingApi.get('/accounts', { params }),
 
+  // Employee: lista SAMO bankinih internih računa (bez client_id)
+  // Koristi se kad aktuar/zaposleni kreira order — biraju se bankini računi
+  getBankAccounts: async () => {
+  const res = await bankingApi.get('/accounts', {
+    params: { page: 1, page_size: 200 },
+  });
+
+  const raw = Array.isArray(res) ? res : res?.data ?? [];
+
+  return raw.filter(a =>
+    a.AccountType === 'Bank' &&
+    a.CompanyID === 1
+  );
+  },
   // Employee: search client by JMBG or email
   searchClient: (query) => {
     const isEmail = String(query).includes('@');
     const params = isEmail ? { email: query } : { jmbg: query };
-    
+
     return coreApi.get('/clients', { params }).then(res => {
       const results = res.data ?? res;
       if (Array.isArray(results) && results.length > 0) return results[0];
       if (results && !Array.isArray(results) && Object.keys(results).length > 0) return results;
-      
+
       const err = new Error('Klijent nije pronađen.');
       err.status = 404;
       throw err;

--- a/src/pages/client/ClientSecurities.jsx
+++ b/src/pages/client/ClientSecurities.jsx
@@ -25,14 +25,14 @@ function applyFilters(list, filters, search) {
     if (filters.exchange && !sec.exchange?.toLowerCase().startsWith(filters.exchange.toLowerCase())) return false;
     if (filters.priceMin !== '' && sec.price < Number(filters.priceMin)) return false;
     if (filters.priceMax !== '' && sec.price > Number(filters.priceMax)) return false;
-    if (filters.bidMin   !== '' && sec.bid   < Number(filters.bidMin))   return false;
-    if (filters.bidMax   !== '' && sec.bid   > Number(filters.bidMax))   return false;
-    if (filters.askMin   !== '' && sec.ask   < Number(filters.askMin))   return false;
-    if (filters.askMax   !== '' && sec.ask   > Number(filters.askMax))   return false;
+    if (filters.bidMin !== '' && sec.bid < Number(filters.bidMin)) return false;
+    if (filters.bidMax !== '' && sec.bid > Number(filters.bidMax)) return false;
+    if (filters.askMin !== '' && sec.ask < Number(filters.askMin)) return false;
+    if (filters.askMax !== '' && sec.ask > Number(filters.askMax)) return false;
     if (filters.volumeMin !== '' && sec.volume < Number(filters.volumeMin)) return false;
     if (filters.volumeMax !== '' && sec.volume > Number(filters.volumeMax)) return false;
     if (filters.settlementDateFrom && sec.settlementDate && sec.settlementDate < filters.settlementDateFrom) return false;
-    if (filters.settlementDateTo   && sec.settlementDate && sec.settlementDate > filters.settlementDateTo)   return false;
+    if (filters.settlementDateTo && sec.settlementDate && sec.settlementDate > filters.settlementDateTo) return false;
     return true;
   });
 }
@@ -49,12 +49,14 @@ function applySort(list, sortBy, sortDir) {
 
 const ORDER_TYPES = [
   { value: 'MARKET', label: 'Market' },
-  { value: 'LIMIT',  label: 'Limit' },
-  { value: 'STOP',   label: 'Stop' },
+  { value: 'LIMIT', label: 'Limit' },
+  { value: 'STOP', label: 'Stop' },
   { value: 'STOP_LIMIT', label: 'Stop Limit' },
 ];
 
 function OrderModal({ security, activeTab, isEmployee, onClose }) {
+  const user = useAuthStore(s => s.user);
+  const clientId = user?.client_id ?? user?.id;
   const [qty, setQty] = useState('');
   const [qtyError, setQtyError] = useState('');
   const [accountNumber, setAccountNumber] = useState('');
@@ -67,13 +69,14 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
   const [showConfirm, setShowConfirm] = useState(false);
   const [error, setError] = useState('');
 
-  const clientId = useAuthStore(s => s.user?.client_id ?? s.user?.id);
-  // Zaposleni koriste bankine račune, klijenti koriste svoje lične račune
-  const { data: accountsData } = useFetch(
-    () => isEmployee ? accountsApi.getAll() : clientApi.getAccounts(clientId),
+  const { data: accountsData, loading: accountsLoading } = useFetch(
+    () => isEmployee ? accountsApi.getBankAccounts() : clientApi.getAccounts(clientId),
     [isEmployee, clientId]
   );
   const accounts = Array.isArray(accountsData) ? accountsData : accountsData?.data ?? [];
+  console.log('CLIENT ACCOUNTS DATA:', accountsData);
+  console.log('CLIENT ACCOUNTS PARSED:', accounts);
+  console.log('USER:', user);
 
   if (!security) return null;
 
@@ -82,9 +85,9 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
   const total = (security.price * qtyNum).toLocaleString('sr-RS', { minimumFractionDigits: 2 });
   const isMarket = orderType === 'MARKET';
   const needsLimit = orderType === 'LIMIT' || orderType === 'STOP_LIMIT';
-  const needsStop  = orderType === 'STOP'  || orderType === 'STOP_LIMIT';
+  const needsStop = orderType === 'STOP' || orderType === 'STOP_LIMIT';
 
-  const selectedAccount = accounts.find(a => (a.account_number ?? a.number) === accountNumber);
+  const selectedAccount = accounts.find(a => isEmployee ? a.AccountNumber === accountNumber : a.account_number === accountNumber);
 
   function handleQtyChange(e) {
     const raw = e.target.value;
@@ -127,7 +130,7 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
 
     // Provera sredstava
     if (selectedAccount) {
-      const balance = selectedAccount.balance ?? selectedAccount.available_balance ?? 0;
+      const balance = selectedAccount?.Balance ?? selectedAccount?.AvailableBalance ?? selectedAccount?.balance ?? selectedAccount?.available_balance ?? 0;
       const estimatedTotal = security.price * n;
       if (balance < estimatedTotal) {
         setError(`Nedovoljno sredstava na računu. Stanje: ${balance.toLocaleString('sr-RS', { minimumFractionDigits: 2 })}, potrebno: ${estimatedTotal.toLocaleString('sr-RS', { minimumFractionDigits: 2 })}`);
@@ -150,12 +153,12 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
 
     try {
       const result = await securitiesApi.buy({
-        listingId:     security.id,
+        listingId: security.id,
         accountNumber: accountNumber,
-        quantity:      Number(qty),
-        orderType:     orderType,
-        limitValue:    needsLimit ? Number(limitValue) : 0,
-        stopValue:     needsStop  ? Number(stopValue)  : 0,
+        quantity: Number(qty),
+        orderType: orderType,
+        limitValue: needsLimit ? Number(limitValue) : 0,
+        stopValue: needsStop ? Number(stopValue) : 0,
       });
 
       setAfterHours(result?.after_hours === true);
@@ -336,12 +339,26 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
                 required
               >
                 <option value="">Izaberite račun...</option>
-                {accounts.map(a => (
-                  <option key={a.account_number ?? a.number} value={a.account_number ?? a.number}>
-                    {a.name} — {a.account_number ?? a.number}
-                    {(a.balance != null) ? ` (${a.balance.toLocaleString('sr-RS', { minimumFractionDigits: 2 })})` : ''}
+                {!accounts.length && !accountsLoading && (
+                  <option value="" disabled>
+                    Nema dostupnih računa
                   </option>
-                ))}
+                )}
+                {accounts.map((a, i) => {
+                  if (isEmployee) {
+                    return (
+                      <option key={a.AccountNumber} value={a.AccountNumber}>
+                        {a.Name} — {a.AccountNumber}
+                      </option>
+                    );
+                  }
+                
+                  return (
+                    <option key={a.account_number || i} value={a.account_number}>
+                      {a.name} — {a.account_number}
+                    </option>
+                  );
+                })}
               </select>
             </div>
 
@@ -390,38 +407,38 @@ export default function ClientSecurities() {
   const pageRef = useRef(null);
   const user = useAuthStore(s => s.user);
 
-  const isEmployee    = user?.identity_type === 'employee';
-  const canSeeForex   = isEmployee;
+  const isEmployee = user?.identity_type === 'employee';
+  const canSeeForex = isEmployee;
   const canSeeOptions = isEmployee;
 
   const [activeTab, setActiveTab] = useState('STOCK');
-  const [selectedSec, setSelectedSec]   = useState(null);
-  const [search,      setSearch]         = useState('');
-  const [filters,     setFilters]        = useState(DEFAULT_FILTERS);
-  const [sortBy,      setSortBy]         = useState('');
-  const [sortDir,     setSortDir]        = useState('desc');
-  const [orderModal,  setOrderModal]     = useState(null);
+  const [selectedSec, setSelectedSec] = useState(null);
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
+  const [sortBy, setSortBy] = useState('');
+  const [sortDir, setSortDir] = useState('desc');
+  const [orderModal, setOrderModal] = useState(null);
 
- 
+
   const fetcher = useCallback(() => {
-    if (activeTab === 'STOCK')   return securitiesApi.getStocks();
+    if (activeTab === 'STOCK') return securitiesApi.getStocks();
     if (activeTab === 'FUTURES') return securitiesApi.getFutures();
-    if (activeTab === 'FOREX')   return securitiesApi.getForex();
+    if (activeTab === 'FOREX') return securitiesApi.getForex();
     if (activeTab === 'OPTIONS') return securitiesApi.getOptions();
     return Promise.resolve([]);
   }, [activeTab]);
 
   const { data: rawData, loading, error, refetch } = useFetch(fetcher, [activeTab]);
 
-const securities = Array.isArray(rawData)
-  ? rawData
-  : rawData?.data ?? [];
+  const securities = Array.isArray(rawData)
+    ? rawData
+    : rawData?.data ?? [];
 
-//console.log('RAW DATA:', rawData);
-//console.log('SECURITIES:', securities);
+  //console.log('RAW DATA:', rawData);
+  //console.log('SECURITIES:', securities);
 
   const filtered = useMemo(() => applyFilters(securities, filters, search), [securities, filters, search]);
-  const sorted   = useMemo(() => applySort(filtered, sortBy, sortDir), [filtered, sortBy, sortDir]);
+  const sorted = useMemo(() => applySort(filtered, sortBy, sortDir), [filtered, sortBy, sortDir]);
 
   //useLayoutEffect(() => {
   //  setSelectedSec(sorted[0] ?? null);
@@ -433,33 +450,33 @@ const securities = Array.isArray(rawData)
     }, pageRef);
     return () => ctx.revert();
   }, [loading, activeTab]);
-/*
-  async function handleSelectSecurity(sec) {
-    try {
-      let details;
-      if (activeTab === 'STOCK')   details = await securitiesApi.getStockById(sec.id);
-      if (activeTab === 'FUTURES') details = await securitiesApi.getFuturesById(sec.id);
-      if (activeTab === 'FOREX')   details = await securitiesApi.getForexById(sec.id);
-      setSelectedSec(details ?? sec);
-    } catch {
-      setSelectedSec(sec);  
+  /*
+    async function handleSelectSecurity(sec) {
+      try {
+        let details;
+        if (activeTab === 'STOCK')   details = await securitiesApi.getStockById(sec.id);
+        if (activeTab === 'FUTURES') details = await securitiesApi.getFuturesById(sec.id);
+        if (activeTab === 'FOREX')   details = await securitiesApi.getForexById(sec.id);
+        setSelectedSec(details ?? sec);
+      } catch {
+        setSelectedSec(sec);  
+      }
     }
-  }
-*/
+  */
 
   async function handleSelectSecurity(sec) {
     setSelectedSec(sec);
     try {
       let details;
-      if (activeTab === 'STOCK')   details = await securitiesApi.getStockById(sec.id);
+      if (activeTab === 'STOCK') details = await securitiesApi.getStockById(sec.id);
       if (activeTab === 'FUTURES') details = await securitiesApi.getFuturesById(sec.id);
-      if (activeTab === 'FOREX')   details = await securitiesApi.getForexById(sec.id);
+      if (activeTab === 'FOREX') details = await securitiesApi.getForexById(sec.id);
       if (details) setSelectedSec(details);
     } catch {
       // fallback to list data
     }
   }
-  
+
   async function handleRefresh(sec) {
     await handleSelectSecurity(sec);
   }
@@ -483,7 +500,7 @@ const securities = Array.isArray(rawData)
   }
 
   const actionConfig = {
-    label:   isEmployee ? 'Kreiraj nalog' : 'Kupi',
+    label: isEmployee ? 'Kreiraj nalog' : 'Kupi',
     handler: sec => setOrderModal(sec),
   };
 
@@ -553,11 +570,11 @@ const securities = Array.isArray(rawData)
             <div className={secStyles.detailPane}>
               {selectedSec
                 ? <SecurityDetails
-                    security={selectedSec}
-                    isEmployee={isEmployee}
-                    onAction={sec => setOrderModal(sec)}
-                    onRefresh={handleRefresh}
-                  />
+                  security={selectedSec}
+                  isEmployee={isEmployee}
+                  onAction={sec => setOrderModal(sec)}
+                  onRefresh={handleRefresh}
+                />
                 : <p style={{ color: 'var(--tx-3)', padding: '2rem' }}>Izaberite hartiju za detalje.</p>
               }
             </div>

--- a/src/pages/client/Neworderpage.jsx
+++ b/src/pages/client/Neworderpage.jsx
@@ -1,0 +1,398 @@
+/**
+ * NewOrderPage.jsx
+ *
+ * Ruta: /create-order
+ * Poziva se iz PortfolioTable kada korisnik klikne SELL dugme:
+ *   navigate('/create-order', { state: asset })
+ *
+ * asset objekat koji stiže iz PortfolioTable:
+ *   { id, ticker, amount, price, profit, lastModified }
+ *
+ * Stranica kreira SELL order preko securitiesApi.sell()
+ * Račun se bira iz liste klijentovih računa (clientApi.getAccounts)
+ * ili bankinih računa ako je zaposleni (accountsApi.getBankAccounts)
+ */
+
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../../store/authStore';
+import { securitiesApi } from '../../api/endpoints/securities';
+import { clientApi } from '../../api/endpoints/client';
+import { accountsApi } from '../../api/endpoints/accounts';
+import { useFetch } from '../../hooks/useFetch';
+import Navbar from '../../components/layout/Navbar';
+import Spinner from '../../components/ui/Spinner';
+import styles from './ClientSubPage.module.css';
+
+const ORDER_TYPES = [
+  { value: 'MARKET',     label: 'Market' },
+  { value: 'LIMIT',      label: 'Limit' },
+  { value: 'STOP',       label: 'Stop' },
+  { value: 'STOP_LIMIT', label: 'Stop Limit' },
+];
+
+export default function NewOrderPage() {
+  const location = useLocation();
+  const navigate  = useNavigate();
+  const asset     = location.state; // { id, ticker, amount, price, ... }
+
+  const user       = useAuthStore(s => s.user);
+  const isEmployee = user?.identity_type === 'employee';
+  const clientId   = user?.client_id ?? user?.id;
+
+  const [qty,        setQty]        = useState('');
+  const [qtyError,   setQtyError]   = useState('');
+  const [accountNumber, setAccountNumber] = useState('');
+  const [orderType,  setOrderType]  = useState('MARKET');
+  const [limitValue, setLimitValue] = useState('');
+  const [stopValue,  setStopValue]  = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted,  setSubmitted]  = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [error,      setError]      = useState('');
+
+  const isMarket   = orderType === 'MARKET';
+  const needsLimit = orderType === 'LIMIT'  || orderType === 'STOP_LIMIT';
+  const needsStop  = orderType === 'STOP'   || orderType === 'STOP_LIMIT';
+
+  // Zaposleni vide bankine račune, klijenti vide svoje
+  const { data: accountsData, loading: accountsLoading } = useFetch(
+    () => isEmployee ? accountsApi.getBankAccounts() : clientApi.getAccounts(clientId),
+    [isEmployee, clientId]
+  );
+  const accounts = Array.isArray(accountsData) ? accountsData : accountsData?.data ?? [];
+
+  const selectedAccount = accounts.find(a => (a.account_number ?? a.number) === accountNumber);
+  const qtyNum  = Number(qty) || 0;
+  const total   = ((asset?.price ?? 0) * qtyNum).toLocaleString('sr-RS', { minimumFractionDigits: 2 });
+  const maxQty  = asset?.amount ?? null; // ne sme da proda više nego što ima
+
+  function handleQtyChange(e) {
+    const raw = e.target.value;
+    setQty(raw);
+    const n = Number(raw);
+    if (raw === '' || isNaN(n)) {
+      setQtyError('');
+    } else if (n <= 0) {
+      setQtyError('Količina mora biti pozitivan broj (veći od 0).');
+    } else if (!Number.isInteger(n)) {
+      setQtyError('Količina mora biti ceo broj.');
+    } else if (maxQty !== null && n > maxQty) {
+      setQtyError(`Ne možete prodati više od ${maxQty} hartija (vaše stanje).`);
+    } else {
+      setQtyError('');
+    }
+  }
+
+  function validate() {
+    setError('');
+    if (!accountNumber) { setError('Izaberite račun.'); return false; }
+    const n = Number(qty);
+    if (!qty || isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+      setQtyError('Količina mora biti pozitivan ceo broj (veći od 0).');
+      return false;
+    }
+    if (maxQty !== null && n > maxQty) {
+      setQtyError(`Ne možete prodati više od ${maxQty} hartija.`);
+      return false;
+    }
+    if (needsLimit && (!limitValue || Number(limitValue) <= 0)) {
+      setError('Unesite validnu limit cenu.'); return false;
+    }
+    if (needsStop && (!stopValue || Number(stopValue) <= 0)) {
+      setError('Unesite validnu stop cenu.'); return false;
+    }
+    return true;
+  }
+
+  function handleProceedToConfirm(e) {
+    e.preventDefault();
+    if (!validate()) return;
+    setShowConfirm(true);
+  }
+
+  async function handleConfirmSubmit() {
+    setSubmitting(true);
+    setError('');
+    try {
+      await securitiesApi.sell({
+        listingId:     asset.id,
+        accountNumber: accountNumber,
+        quantity:      Number(qty),
+        orderType:     orderType,
+        limitValue:    needsLimit ? Number(limitValue) : 0,
+        stopValue:     needsStop  ? Number(stopValue)  : 0,
+      });
+      setSubmitted(true);
+      setShowConfirm(false);
+    } catch (err) {
+      setError(err?.message || 'Greška pri prodaji. Pokušajte ponovo.');
+      setShowConfirm(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Ako nije stigao asset (direktna navigacija bez state-a)
+  if (!asset) {
+    return (
+      <div className={styles.pageContainer}>
+        <Navbar />
+        <main className={styles.pageContent}>
+          <p style={{ color: 'var(--tx-3)', padding: '2rem' }}>
+            Nema podataka o hartiji. Idite na portfolio i kliknite SELL.
+          </p>
+          <button className={styles.submitBtn} onClick={() => navigate(-1)}>Nazad</button>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.pageContainer}>
+      <Navbar />
+      <main className={styles.pageContent} style={{ maxWidth: 520 }}>
+
+        <div className={styles.pageHeader}>
+          <p className={styles.pageEyebrow}>Portfolio</p>
+          <h1 className={styles.pageTitle}>Prodaj hartiju</h1>
+        </div>
+
+        {submitted ? (
+          /* ── Uspešno ── */
+          <div className={styles.formCard} style={{ textAlign: 'center', padding: '2rem' }}>
+            <div className={styles.successBanner}>
+              {isEmployee
+                ? '✓ Sell order je kreiran i čeka odobrenje.'
+                : '✓ Sell order je kreiran i u obradi.'}
+            </div>
+            {isEmployee && (
+              <p style={{ fontSize: 13, color: 'var(--tx-2)', marginTop: 12 }}>
+                Hartija će biti skinuta sa portoflia tek nakon odobrenja.
+              </p>
+            )}
+            <div style={{ display: 'flex', gap: 10, marginTop: 20, justifyContent: 'center' }}>
+              <button className={styles.submitBtn} onClick={() => navigate(-1)}>
+                Nazad na portfolio
+              </button>
+            </div>
+          </div>
+
+        ) : showConfirm ? (
+          /* ── Potvrda ── */
+          <div className={styles.formCard}>
+            <h4 style={{ fontSize: 15, fontWeight: 700, color: 'var(--tx-1)', marginTop: 0, marginBottom: 16 }}>
+              Potvrda SELL ordera
+            </h4>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 14, color: 'var(--tx-1)' }}>
+              <Row label="Hartija"      value={`${asset.ticker}`} />
+              <Row label="Broj hartija" value={qty} />
+              <Row label="Tip ordera"   value={ORDER_TYPES.find(t => t.value === orderType)?.label} />
+              {isMarket && (
+                <Row label="Cena" value="Koristi se tržišna cena" italic />
+              )}
+              {needsLimit && (
+                <Row label="Limit cena" value={`${Number(limitValue).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}`} />
+              )}
+              {needsStop && (
+                <Row label="Stop cena" value={`${Number(stopValue).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}`} />
+              )}
+              <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10, display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--tx-2)' }}>Aproximativna vrednost:</span>
+                <strong style={{ fontSize: 16, color: 'var(--accent)' }}>{total}</strong>
+              </div>
+            </div>
+
+            {error && <p style={{ fontSize: 13, color: 'var(--red)', margin: '12px 0 0' }}>{error}</p>}
+
+            <div style={{ display: 'flex', gap: 10, marginTop: 20 }}>
+              <button
+                type="button"
+                className={styles.submitBtn}
+                style={{ flex: 1, background: 'var(--bg)', color: 'var(--tx-2)', border: '1px solid var(--border)' }}
+                onClick={() => setShowConfirm(false)}
+                disabled={submitting}
+              >
+                Nazad
+              </button>
+              <button
+                type="button"
+                className={styles.submitBtn}
+                style={{ flex: 2 }}
+                onClick={handleConfirmSubmit}
+                disabled={submitting}
+              >
+                {submitting ? 'Slanje...' : 'Potvrdi prodaju'}
+              </button>
+            </div>
+          </div>
+
+        ) : (
+          /* ── Forma ── */
+          <form className={styles.formCard} onSubmit={handleProceedToConfirm}>
+
+            <div className={styles.formField}>
+              <label>Hartija</label>
+              <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--accent)' }}>
+                {asset.ticker}
+                {maxQty !== null && (
+                  <span style={{ fontWeight: 400, color: 'var(--tx-3)', marginLeft: 8 }}>
+                    (imate {maxQty} komada)
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className={styles.formField}>
+              <label>Cena po jedinici</label>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>
+                ${asset.price?.toLocaleString('sr-RS', { minimumFractionDigits: 2 })}
+              </div>
+            </div>
+
+            <div className={styles.formField}>
+              <label>Tip ordera</label>
+              <select
+                className={styles.formInput}
+                value={orderType}
+                onChange={e => setOrderType(e.target.value)}
+              >
+                {ORDER_TYPES.map(t => (
+                  <option key={t.value} value={t.value}>{t.label}</option>
+                ))}
+              </select>
+              {isMarket && (
+                <p style={{ fontSize: 12, color: 'var(--tx-3)', margin: '4px 0 0', fontStyle: 'italic' }}>
+                  Koristi se trenutna tržišna (market) cena.
+                </p>
+              )}
+            </div>
+
+            {needsLimit && (
+              <div className={styles.formField}>
+                <label>Limit cena</label>
+                <input
+                  className={styles.formInput}
+                  type="number" min="0.01" step="0.01"
+                  placeholder="Unesite limit cenu..."
+                  value={limitValue}
+                  onChange={e => setLimitValue(e.target.value)}
+                  required
+                />
+              </div>
+            )}
+
+            {needsStop && (
+              <div className={styles.formField}>
+                <label>Stop cena</label>
+                <input
+                  className={styles.formInput}
+                  type="number" min="0.01" step="0.01"
+                  placeholder="Unesite stop cenu..."
+                  value={stopValue}
+                  onChange={e => setStopValue(e.target.value)}
+                  required
+                />
+              </div>
+            )}
+
+            <div className={styles.formField}>
+              <label>Račun za uplatu prihoda</label>
+              {accountsLoading ? (
+                <Spinner />
+              ) : (
+                <select
+                  className={styles.formInput}
+                  value={accountNumber}
+                  onChange={e => setAccountNumber(e.target.value)}
+                  required
+                >
+                  <option value="">
+                    {isEmployee ? 'Izaberite bankini račun...' : 'Izaberite račun...'}
+                  </option>
+                  {accounts.map(a => (
+                    <option key={a.account_number ?? a.number} value={a.account_number ?? a.number}>
+                      {a.name} — {a.account_number ?? a.number}
+                      {a.balance != null
+                        ? ` (${a.balance.toLocaleString('sr-RS', { minimumFractionDigits: 2 })})`
+                        : ''}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {accounts.length === 0 && !accountsLoading && (
+                <p style={{ fontSize: 12, color: 'var(--red)', margin: '4px 0 0' }}>
+                  {isEmployee
+                    ? 'Nisu pronađeni bankini interni računi.'
+                    : 'Nemate aktivnih računa.'}
+                </p>
+              )}
+            </div>
+
+            <div className={styles.formField}>
+              <label>Količina za prodaju</label>
+              <input
+                className={styles.formInput}
+                type="number" step="1" min="1"
+                max={maxQty ?? undefined}
+                placeholder={maxQty ? `1 – ${maxQty}` : 'Unesite količinu...'}
+                value={qty}
+                onChange={handleQtyChange}
+                required
+              />
+              {qtyError && (
+                <p style={{ fontSize: 12, color: 'var(--red)', margin: '4px 0 0', fontWeight: 600 }}>
+                  {qtyError}
+                </p>
+              )}
+            </div>
+
+            <div className={styles.formField}>
+              <label>Aproximativna vrednost prodaje</label>
+              <div style={{ fontSize: 17, fontWeight: 800, color: 'var(--tx-1)' }}>{total}</div>
+            </div>
+
+            {isEmployee && (
+              <p style={{ fontSize: 12, color: 'var(--tx-3)', margin: 0 }}>
+                Sell order ide na odobrenje. Hartija se skida tek nakon odobrenja.
+              </p>
+            )}
+
+            {error && <p style={{ fontSize: 13, color: 'var(--red)', margin: 0 }}>{error}</p>}
+
+            <div style={{ display: 'flex', gap: 10 }}>
+              <button
+                type="button"
+                className={styles.submitBtn}
+                style={{ flex: 1, background: 'var(--bg)', color: 'var(--tx-2)', border: '1px solid var(--border)' }}
+                onClick={() => navigate(-1)}
+              >
+                Otkaži
+              </button>
+              <button
+                type="submit"
+                className={styles.submitBtn}
+                style={{ flex: 2 }}
+                disabled={submitting || !!qtyError}
+              >
+                {submitting ? 'Slanje...' : 'Nastavi'}
+              </button>
+            </div>
+          </form>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// Helper komponenta za red u confirmation dijalogu
+function Row({ label, value, italic }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <span style={{ color: 'var(--tx-2)' }}>{label}:</span>
+      <strong style={italic ? { fontStyle: 'italic', color: 'var(--tx-2)', fontWeight: 400 } : {}}>
+        {value}
+      </strong>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview

This PR fixes account selection behavior in the order modal for both employee (actuary) and client flows.

## Changes

- Fixed account dropdown for employees:
  - Now correctly shows only bank internal accounts
  - Uses proper filtering (`AccountType === 'Bank'` and `CompanyID === 1`)

- Fixed account dropdown for clients:
  - Now correctly displays client-owned accounts
  - Handles different API response formats (PascalCase vs snake_case)

- Fixed account selection logic:
  - Properly resolves selected account for both employee and client flows

- Fixed balance validation:
  - Supports both backend formats (`Balance` / `balance`, etc.)
  - Prevents false "insufficient funds" errors

- Added empty state handling:
  - Shows message when user has no available accounts instead of empty dropdown

## Notes / Limitations

- `Neworderpage.jsx` is currently not fully implemented (missing account selection logic)
- Sell order form is not implemented yet (only buy flow is covered)

## Testing

- Employee:
  - Can select only bank accounts when creating order ✔️

- Client:
  - Can select their own accounts ✔️
  - Empty state shown if no accounts exist ✔️

## Remaining Work

- Implement SELL order flow (form similar to BUY)
- Complete `Neworderpage.jsx`