### PR TITLE
Add sell order modal for clients and employees (actuaries)

### DIFF
--- a/src/api/endpoints/securities.js
+++ b/src/api/endpoints/securities.js
@@ -234,16 +234,30 @@ export const securitiesApi = {
   },
 
   buy(data) {
-  return api.post('/orders', {
-    account_number: data.accountNumber,
-    listing_id:     data.listingId,
-    direction:      'BUY',
-    order_type:     data.orderType ?? 'MARKET',
-    quantity:       data.quantity,
-    all_or_none:    false,
-    margin:         false,
-    limit_value:    data.limitValue ?? 0,
-    stop_value:     data.stopValue  ?? 0,
-  });
-}
+    return api.post('/orders', {
+      account_number: data.accountNumber,
+      listing_id:     data.listingId,
+      direction:      'BUY',
+      order_type:     data.orderType ?? 'MARKET',
+      quantity:       data.quantity,
+      all_or_none:    data.allOrNone ?? false,
+      margin:         data.margin ?? false,
+      limit_value:    data.limitValue ?? 0,
+      stop_value:     data.stopValue  ?? 0,
+    });
+  },
+
+  sell(data) {
+    return api.post('/orders', {
+      account_number: data.accountNumber,
+      listing_id:     data.listingId,
+      direction:      'SELL',
+      order_type:     data.orderType ?? 'MARKET',
+      quantity:       data.quantity,
+      all_or_none:    data.allOrNone ?? false,
+      margin:         data.margin ?? false,
+      limit_value:    data.limitValue ?? 0,
+      stop_value:     data.stopValue  ?? 0,
+    });
+  },
 };

--- a/src/features/portfolio/PortfolioTable.jsx
+++ b/src/features/portfolio/PortfolioTable.jsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import styles from './PortfolioTable.module.css';
 
-export default function PortfolioTable({ assets, isAdmin }) {
+export default function PortfolioTable({ assets, isAdmin, onSell }) {
   const navigate = useNavigate();
 
   return (
@@ -32,9 +32,9 @@ export default function PortfolioTable({ assets, isAdmin }) {
               <td>
                 <div className={styles.actionCell}>
                   {/* SELL dugme za sve */}
-                  <button 
+                  <button
                     className={styles.sellBtn}
-                    onClick={() => navigate('/create-order', { state: asset })}
+                    onClick={() => onSell?.(asset)}
                   >
                     SELL
                   </button>

--- a/src/features/portfolio/SellOrderModal.jsx
+++ b/src/features/portfolio/SellOrderModal.jsx
@@ -1,0 +1,263 @@
+import { useState, useEffect } from 'react';
+import { clientApi } from '../../api/endpoints/client';
+import { accountsApi } from '../../api/endpoints/accounts';
+import { securitiesApi } from '../../api/endpoints/securities';
+import modalStyles from '../../pages/client/ClientSubPage.module.css';
+
+const ORDER_TYPES = [
+  { value: 'MARKET',     label: 'Market' },
+  { value: 'LIMIT',      label: 'Limit' },
+  { value: 'STOP',       label: 'Stop' },
+  { value: 'STOP_LIMIT', label: 'Stop Limit' },
+];
+
+export default function SellOrderModal({ asset, clientId, isEmployee, onClose, onSuccess }) {
+  const [qty, setQty]                     = useState('');
+  const [qtyError, setQtyError]           = useState('');
+  const [orderType, setOrderType]         = useState('MARKET');
+  const [limitValue, setLimitValue]       = useState('');
+  const [stopValue, setStopValue]         = useState('');
+  const [accountNumber, setAccountNumber] = useState('');
+  const [margin, setMargin]               = useState(false);
+  const [allOrNone, setAllOrNone]         = useState(false);
+  const [accounts, setAccounts]           = useState([]);
+  const [showConfirm, setShowConfirm]     = useState(false);
+  const [submitting, setSubmitting]       = useState(false);
+  const [submitted, setSubmitted]         = useState(false);
+  const [error, setError]                 = useState('');
+
+  const needsLimit = orderType === 'LIMIT'      || orderType === 'STOP_LIMIT';
+  const needsStop  = orderType === 'STOP'       || orderType === 'STOP_LIMIT';
+
+  useEffect(() => {
+    const fetch = isEmployee
+      ? accountsApi.getAll({ page: 1, page_size: 100 })
+      : clientApi.getAccounts(clientId);
+
+    fetch
+      .then(res => {
+        const list = Array.isArray(res) ? res : res?.data ?? [];
+        const filtered = isEmployee
+          ? list.filter(a => (a.account_type ?? a.AccountType)?.toUpperCase() === 'BANK')
+          : list;
+        setAccounts(filtered);
+      })
+      .catch(() => {});
+  }, [clientId, isEmployee]);
+
+  function handleQtyChange(e) {
+    const raw = e.target.value;
+    setQty(raw);
+    const n = Number(raw);
+    if (raw === '' || isNaN(n)) { setQtyError(''); return; }
+    if (n <= 0 || !Number.isInteger(n)) {
+      setQtyError('Količina mora biti pozitivan ceo broj.');
+    } else if (n > asset.amount) {
+      setQtyError(`Nemate dovoljno. Posedujete: ${asset.amount}.`);
+    } else {
+      setQtyError('');
+    }
+  }
+
+  function validate() {
+    setError('');
+    if (!accountNumber) { setError('Izaberite račun.'); return false; }
+    const n = Number(qty);
+    if (!qty || isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+      setQtyError('Količina mora biti pozitivan ceo broj.'); return false;
+    }
+    if (n > asset.amount) {
+      setQtyError(`Nemate dovoljno. Posedujete: ${asset.amount}.`); return false;
+    }
+    if (needsLimit && (!limitValue || Number(limitValue) <= 0)) {
+      setError('Unesite validnu limit cenu.'); return false;
+    }
+    if (needsStop && (!stopValue || Number(stopValue) <= 0)) {
+      setError('Unesite validnu stop cenu.'); return false;
+    }
+    return true;
+  }
+
+  function handleProceed(e) {
+    e.preventDefault();
+    if (validate()) setShowConfirm(true);
+  }
+
+  async function handleConfirm() {
+    setSubmitting(true);
+    setError('');
+    try {
+      await securitiesApi.sell({
+        listingId:     asset.assetId,
+        accountNumber,
+        quantity:      Number(qty),
+        orderType,
+        limitValue:    needsLimit ? Number(limitValue) : 0,
+        stopValue:     needsStop  ? Number(stopValue)  : 0,
+        margin,
+        allOrNone,
+      });
+      setSubmitted(true);
+      setShowConfirm(false);
+      onSuccess?.();
+    } catch (err) {
+      setError(err?.message || 'Greška pri prodaji. Pokušajte ponovo.');
+      setShowConfirm(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={modalStyles.modalOverlay} onClick={onClose}>
+      <div className={modalStyles.modal} onClick={e => e.stopPropagation()} style={{ maxWidth: 460 }}>
+        <div className={modalStyles.modalHeader}>
+          <h3>Prodaj — {asset.ticker}</h3>
+          <button className={modalStyles.modalClose} onClick={onClose}>✕</button>
+        </div>
+
+        {submitted ? (
+          <div style={{ padding: '2rem', textAlign: 'center' }}>
+            <div className={modalStyles.successBanner}>✓ Sell order je kreiran i čeka odobrenje.</div>
+            <p style={{ fontSize: 13, color: 'var(--tx-2)', marginTop: 12 }}>
+              Akcije će biti sklonjene sa portfolija tek nakon odobrenja.
+            </p>
+          </div>
+        ) : showConfirm ? (
+          <div style={{ padding: '1.5rem' }}>
+            <h4 style={{ fontSize: 15, fontWeight: 700, margin: '0 0 16px' }}>Potvrda prodaje</h4>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 14 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--tx-2)' }}>Hartija:</span>
+                <strong>{asset.ticker}</strong>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--tx-2)' }}>Količina:</span>
+                <strong>{qty}</strong>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--tx-2)' }}>Tip ordera:</span>
+                <strong>{ORDER_TYPES.find(t => t.value === orderType)?.label}</strong>
+              </div>
+              {needsLimit && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--tx-2)' }}>Limit cena:</span>
+                  <strong>{Number(limitValue).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}</strong>
+                </div>
+              )}
+              {needsStop && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--tx-2)' }}>Stop cena:</span>
+                  <strong>{Number(stopValue).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}</strong>
+                </div>
+              )}
+              {allOrNone && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--tx-2)' }}>All or None:</span><strong>Da</strong>
+                </div>
+              )}
+              {margin && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--tx-2)' }}>Margin:</span><strong>Da</strong>
+                </div>
+              )}
+            </div>
+            {error && <p style={{ fontSize: 13, color: 'var(--red)', margin: '12px 0 0' }}>{error}</p>}
+            <div style={{ display: 'flex', gap: 10, marginTop: 20 }}>
+              <button type="button" className={modalStyles.submitBtn}
+                style={{ flex: 1, background: 'var(--bg)', color: 'var(--tx-2)', border: '1px solid var(--border)' }}
+                onClick={() => setShowConfirm(false)} disabled={submitting}>
+                Nazad
+              </button>
+              <button type="button" className={modalStyles.submitBtn}
+                style={{ flex: 2, background: '#ef4444' }}
+                onClick={handleConfirm} disabled={submitting}>
+                {submitting ? 'Slanje...' : 'Potvrdi prodaju'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <form className={modalStyles.formCard} style={{ boxShadow: 'none', border: 'none' }} onSubmit={handleProceed}>
+            <div className={modalStyles.formField}>
+              <label>Hartija</label>
+              <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--accent)' }}>
+                {asset.ticker} — posedujete {asset.amount} kom
+              </div>
+            </div>
+
+            <div className={modalStyles.formField}>
+              <label>Tip ordera</label>
+              <select className={modalStyles.formInput} value={orderType} onChange={e => setOrderType(e.target.value)}>
+                {ORDER_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+              </select>
+            </div>
+
+            {needsLimit && (
+              <div className={modalStyles.formField}>
+                <label>Limit cena</label>
+                <input className={modalStyles.formInput} type="number" min="0.01" step="0.01"
+                  placeholder="Unesite limit cenu..." value={limitValue}
+                  onChange={e => setLimitValue(e.target.value)} required />
+              </div>
+            )}
+
+            {needsStop && (
+              <div className={modalStyles.formField}>
+                <label>Stop cena</label>
+                <input className={modalStyles.formInput} type="number" min="0.01" step="0.01"
+                  placeholder="Unesite stop cenu..." value={stopValue}
+                  onChange={e => setStopValue(e.target.value)} required />
+              </div>
+            )}
+
+            <div className={modalStyles.formField}>
+              <label>Račun</label>
+              <select className={modalStyles.formInput} value={accountNumber}
+                onChange={e => setAccountNumber(e.target.value)} required>
+                <option value="">Izaberite račun...</option>
+                {accounts.map((a, i) => {
+                  const num  = a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number ?? '';
+                  const name = a.Name ?? a.name ?? a.ownerName ?? a.owner_name ?? a.owner ?? '';
+                  const bal  = a.Balance ?? a.AvailableBalance ?? a.balance ?? a.available_balance ?? a.availableBalance;
+                  const cur  = a.Currency?.Code ?? a.currency ?? a.Currency ?? '';
+                  const label = name || num || `Račun ${i + 1}`;
+                  return (
+                    <option key={num || i} value={num}>
+                      {label}{name && num ? ` — ${num}` : ''}
+                      {bal != null ? ` (${Number(bal).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}${cur ? ` ${cur}` : ''})` : ''}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+
+            <div className={modalStyles.formField}>
+              <label>Količina</label>
+              <input className={modalStyles.formInput} type="number" step="1" min="1" max={asset.amount}
+                placeholder={`Max: ${asset.amount}`} value={qty} onChange={handleQtyChange} required />
+              {qtyError && <p style={{ fontSize: 12, color: 'var(--red)', margin: '4px 0 0', fontWeight: 600 }}>{qtyError}</p>}
+            </div>
+
+            <div style={{ display: 'flex', gap: 20 }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' }}>
+                <input type="checkbox" checked={margin} onChange={e => setMargin(e.target.checked)} />
+                Margin
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' }}>
+                <input type="checkbox" checked={allOrNone} onChange={e => setAllOrNone(e.target.checked)} />
+                All or None
+              </label>
+            </div>
+
+            {error && <p style={{ fontSize: 13, color: 'var(--red)', margin: 0 }}>{error}</p>}
+
+            <button type="submit" className={modalStyles.submitBtn}
+              style={{ background: '#ef4444' }} disabled={!!qtyError}>
+              Nastavi
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/PortfolioPage.jsx
+++ b/src/pages/admin/PortfolioPage.jsx
@@ -8,6 +8,7 @@ import ProfitSummary from '../../features/portfolio/ProfitSummary';
 import TaxSummary from '../../features/portfolio/TaxSummary';
 import OptionsSection from '../../features/portfolio/OptionsSection';
 import { portfolioApi } from '../../api/endpoints/portfolio';
+import SellOrderModal from '../../features/portfolio/SellOrderModal';
 import styles from './PortfolioPage.module.css';
 
 const FAKE_PORTFOLIO_ASSETS = [
@@ -31,6 +32,7 @@ export default function PortfolioPage() {
     tax: { taxPaid: 0, taxUnpaid: 0 }
   });
   const [loading, setLoading] = useState(false);
+  const [sellModal, setSellModal] = useState(null);
 
   useEffect(() => {
     if (!user) initFromStorage();
@@ -90,9 +92,21 @@ export default function PortfolioPage() {
 
   if (!user) return null;
 
+  const clientId = user?.client_id ?? user?.id;
+
   return (
     <div ref={pageRef} className={styles.stranica}>
       <Navbar />
+
+      {sellModal && (
+        <SellOrderModal
+          asset={sellModal}
+          clientId={clientId}
+          isEmployee
+          onClose={() => setSellModal(null)}
+          onSuccess={() => setSellModal(null)}
+        />
+      )}
       <main className={styles.sadrzaj}>
         
         <div className="page-anim">
@@ -115,7 +129,7 @@ export default function PortfolioPage() {
         {/* TABELA 1: Akcije */}
         <div className={`page-anim ${styles.tableCard}`}>
           <div className={styles.cardHeader}><h3>Hartije od vrednosti</h3></div>
-          <PortfolioTable assets={data.stocks} isAdmin={canManageOTC} />
+          <PortfolioTable assets={data.stocks} isAdmin={canManageOTC} onSell={asset => setSellModal(asset)} />
         </div>
 
         {/* TABELA 2: Opcije */}

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../store/authStore';
 import { portfolioApi } from '../../api/endpoints/portfolio';
 import ClientHeader from '../../components/layout/ClientHeader';
 import PortfolioTable from '../../features/portfolio/PortfolioTable';
+import SellOrderModal from '../../features/portfolio/SellOrderModal';
 import ProfitSummary from '../../features/portfolio/ProfitSummary';
 import TaxSummary from '../../features/portfolio/TaxSummary';
 import Spinner from '../../components/ui/Spinner';
@@ -12,79 +13,70 @@ import styles from './ClientPortfolioPage.module.css';
 
 export default function ClientPortfolioPage() {
   const pageRef = useRef(null);
-  
-  // State usklađen sa strukturom podataka
-  const [portfolio, setPortfolio] = useState({
-    stocks: [],
-    tax: { taxPaid: 0, taxUnpaid: 0 }
-  });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  
+
+  const [portfolio, setPortfolio] = useState({ stocks: [], tax: { taxPaid: 0, taxUnpaid: 0 } });
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [sellModal, setSellModal] = useState(null);
+
   const user = useAuthStore(s => s.user);
   const initFromStorage = useAuthStore(s => s.initFromStorage);
 
-  // 1. Inicijalizacija korisnika
   useEffect(() => {
     if (!user) initFromStorage();
   }, [user, initFromStorage]);
 
-  // 2. Učitavanje podataka preko endpointa (Trading API - Port 8082)
   useEffect(() => {
     const loadData = async () => {
       if (!user?.id) return;
-
       try {
         setLoading(true);
         setError(null);
-        
         const clientId = user.client_id ?? user.id;
         const res = await portfolioApi.getClientPortfolio(clientId);
-        
-        // Uzimamo podatke (client.js interceptor bi trebalo da već vraća res.data)
         const rawData = res?.data || res;
         const allAssets = Array.isArray(rawData) ? rawData : (rawData?.assets ?? []);
-
         setPortfolio({
           stocks: allAssets.filter(a => a.type?.toUpperCase() === 'STOCK'),
-          tax: rawData?.tax ?? { taxPaid: 0, taxUnpaid: 0 }
+          tax: rawData?.tax ?? { taxPaid: 0, taxUnpaid: 0 },
         });
       } catch (err) {
-        console.error("Greška pri učitavanju klijentskog portfolija:", err);
-        setError("Nije moguće učitati podatke portfolija.");
+        console.error('Greška pri učitavanju portfolija:', err);
+        setError('Nije moguće učitati podatke portfolija.');
       } finally {
         setLoading(false);
       }
     };
-
     loadData();
   }, [user?.id]);
 
-  // 3. GSAP Animacija
   useLayoutEffect(() => {
     if (!loading && portfolio) {
       const ctx = gsap.context(() => {
-        gsap.from('.page-anim', { 
-          opacity: 0, 
-          y: 20, 
-          duration: 0.4, 
-          stagger: 0.1, 
-          ease: 'power2.out' 
-        });
+        gsap.from('.page-anim', { opacity: 0, y: 20, duration: 0.4, stagger: 0.1, ease: 'power2.out' });
       }, pageRef);
       return () => ctx.revert();
     }
   }, [loading, portfolio]);
+
+  const clientId = user?.client_id ?? user?.id;
 
   if (!user) return null;
 
   return (
     <div ref={pageRef} className={styles.stranica}>
       <ClientHeader activeNav="portfolio" />
-      
+
+      {sellModal && (
+        <SellOrderModal
+          asset={sellModal}
+          clientId={clientId}
+          onClose={() => setSellModal(null)}
+          onSuccess={() => setSellModal(null)}
+        />
+      )}
+
       <main className={styles.sadrzaj}>
-        
-        {/* Header Sekcija */}
         <div className="page-anim">
           <div className={styles.breadcrumb}><span>Moj nalog</span></div>
           <div className={styles.pageHeader}>
@@ -102,33 +94,26 @@ export default function ClientPortfolioPage() {
           <div className={styles.center}><Alert tip="greska" poruka={error} /></div>
         ) : (
           <>
-            {/* Profitna kartica */}
             <div className="page-anim">
               <ProfitSummary assets={portfolio.stocks} />
             </div>
 
-            {/* Tabela sa akcijama */}
             <div className={`page-anim ${styles.tableCard}`}>
               <div className={styles.cardHeader}>
                 <h3>Moje akcije (Stocks)</h3>
               </div>
-              <PortfolioTable 
-                assets={portfolio.stocks} 
-                isAdmin={false} 
+              <PortfolioTable
+                assets={portfolio.stocks}
+                isAdmin={false}
+                onSell={asset => setSellModal(asset)}
               />
             </div>
 
-            {/* Info labela */}
             <div className="page-anim" style={{ marginTop: '32px', paddingBottom: '40px' }}>
-              <div style={{ 
-                backgroundColor: '#f1f5f9', 
-                padding: '16px', 
-                borderRadius: '12px',
-                textAlign: 'center'
-              }}>
+              <div style={{ backgroundColor: '#f1f5f9', padding: '16px', borderRadius: '12px', textAlign: 'center' }}>
                 <p style={{ fontSize: '13px', color: '#475569', margin: 0 }}>
-                  💡 <strong>Napomena:</strong> Za prodaju određenih akcija kliknite na dugme <strong>SELL</strong>. 
-                  Sredstva će biti automatski prebačena na vaš primarni račun nakon obrade transakcije.
+                  Za prodaju određenih akcija kliknite na dugme <strong>SELL</strong>.
+                  Sredstva će biti prebačena na vaš račun tek nakon odobrenja.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
- Add SellOrderModal component with hartija, tip ordera, limit/stop cena, racun, margin, all-or-none, and confirmation step
- Employees fetch bank accounts (account_type=BANK), clients fetch their own accounts
- Wire SELL button in PortfolioTable to open modal instead of navigating to missing /create-order route
- Add securitiesApi.sell() with direction: SELL, also fix buy() to pass margin/allOrNone from caller
- Used in both ClientPortfolioPage and PortfolioPage (admin/employee)