### PR TITLE
Fix agent name in supervisor orders, bank account filtering, and empt…

### DIFF
--- a/src/api/endpoints/accounts.js
+++ b/src/api/endpoints/accounts.js
@@ -4,6 +4,16 @@ export const accountsApi = {
   // Employee: list all accounts (paginated, filterable)
   getAll: (params) => bankingApi.get('/accounts', { params }),
 
+  // Employee: lista samo bankinih internih računa (AccountType === 'Bank' && CompanyID === 1)
+  getBankAccounts: async () => {
+    const res = await bankingApi.get('/accounts', { params: { page: 1, page_size: 200 } });
+    const raw = Array.isArray(res) ? res : (res?.data ?? []);
+    return raw.filter(a =>
+      (a.AccountType ?? a.account_type ?? '').toLowerCase() === 'bank' &&
+      (a.CompanyID ?? a.company_id) === 1
+    );
+  },
+
   // Employee: search client by JMBG or email
   searchClient: (query) => {
     const isEmail = String(query).includes('@');

--- a/src/api/endpoints/orders.js
+++ b/src/api/endpoints/orders.js
@@ -3,12 +3,15 @@ import {tradingApi} from '../client';
 
 const userNameCache = {};
 
-export async function fetchUserName(userId) {
+export async function fetchUserName(userId, ownerType) {
   if (!userId) return '—';
-  if (userNameCache[userId] !== undefined) return userNameCache[userId];
+  const cacheKey = `${ownerType ?? ''}:${userId}`;
+  if (userNameCache[cacheKey] !== undefined) return userNameCache[cacheKey];
 
   try {
-    const res = await api.get('/clients', { params: { page: 1, page_size: 9999 } });
+    const endpoint = ownerType === 'ACTUARY' ? '/actuaries' : '/clients';
+    const pageSize = ownerType === 'ACTUARY' ? 100 : 9999;
+    const res = await api.get(endpoint, { params: { page: 1, page_size: pageSize } });
     const list = Array.isArray(res) ? res : (res?.data ?? []);
     const found = list.find(c =>
       String(c.id) === String(userId) ||
@@ -17,10 +20,10 @@ export async function fetchUserName(userId) {
     const name = found
       ? [found.first_name, found.last_name].filter(Boolean).join(' ') || found.name || '—'
       : '—';
-    userNameCache[userId] = name;
+    userNameCache[cacheKey] = name;
     return name;
   } catch {
-    userNameCache[userId] = '—';
+    userNameCache[cacheKey] = '—';
     return '—';
   }
 }

--- a/src/features/portfolio/SellOrderModal.jsx
+++ b/src/features/portfolio/SellOrderModal.jsx
@@ -31,16 +31,13 @@ export default function SellOrderModal({ asset, clientId, isEmployee, onClose, o
 
   useEffect(() => {
     const fetch = isEmployee
-      ? accountsApi.getAll({ page: 1, page_size: 100 })
+      ? accountsApi.getBankAccounts()
       : clientApi.getAccounts(clientId);
 
     fetch
       .then(res => {
         const list = Array.isArray(res) ? res : res?.data ?? [];
-        const filtered = isEmployee
-          ? list.filter(a => (a.account_type ?? a.AccountType)?.toUpperCase() === 'BANK')
-          : list;
-        setAccounts(filtered);
+        setAccounts(list);
       })
       .catch(() => {});
   }, [clientId, isEmployee]);
@@ -233,6 +230,11 @@ export default function SellOrderModal({ asset, clientId, isEmployee, onClose, o
                   );
                 })}
               </select>
+              {accounts.length === 0 && (
+                <p style={{ fontSize: 12, color: 'var(--red)', margin: '4px 0 0' }}>
+                  {isEmployee ? 'Nisu pronađeni bankini interni računi.' : 'Nemate aktivnih računa.'}
+                </p>
+              )}
             </div>
 
             <div className={modalStyles.formField}>

--- a/src/pages/client/ClientSecurities.jsx
+++ b/src/pages/client/ClientSecurities.jsx
@@ -72,16 +72,13 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
   const [error, setError] = useState('');
 
   const clientId = useAuthStore(s => s.user?.client_id ?? s.user?.id);
-  const { data: accountsData } = useFetch(
-    () => isEmployee ? accountsApi.getAll({ page: 1, page_size: 100 }) : clientApi.getAccounts(clientId),
+  const { data: accountsData, loading: accountsLoading } = useFetch(
+    () => isEmployee ? accountsApi.getBankAccounts() : clientApi.getAccounts(clientId),
     [isEmployee, clientId]
   );
-  const allAccounts = Array.isArray(accountsData)
+  const accounts = Array.isArray(accountsData)
     ? accountsData
     : accountsData?.data ?? accountsData?.content ?? [];
-  const accounts = isEmployee
-    ? allAccounts.filter(a => (a.account_type ?? a.AccountType)?.toUpperCase() === 'BANK')
-    : allAccounts;
 
   const { data: loansData, loading: loansLoading } = useFetch(
     () => (!clientId || isEmployee) ? Promise.resolve([]) : loansApi.getMyLoans(clientId),
@@ -395,7 +392,9 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
                 onChange={e => setAccountNumber(e.target.value)}
                 required
               >
-                <option value="">Izaberite račun...</option>
+                <option value="">
+                  {accountsLoading ? 'Učitavanje...' : 'Izaberite račun...'}
+                </option>
                 {accounts.map((a, i) => {
                   const num  = a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number ?? '';
                   const name = a.Name ?? a.name ?? a.owner_name ?? a.ownerName ?? a.owner ?? `Račun ${i + 1}`;
@@ -409,6 +408,11 @@ function OrderModal({ security, activeTab, isEmployee, onClose }) {
                   );
                 })}
               </select>
+              {!accountsLoading && accounts.length === 0 && (
+                <p style={{ fontSize: 12, color: 'var(--red)', margin: '4px 0 0' }}>
+                  {isEmployee ? 'Nisu pronađeni bankini interni računi.' : 'Nemate aktivnih računa.'}
+                </p>
+              )}
             </div>
 
             <div className={styles.formField}>

--- a/src/pages/supervisor/SupervisorOrdersPage.jsx
+++ b/src/pages/supervisor/SupervisorOrdersPage.jsx
@@ -155,17 +155,19 @@ export default function SupervisorOrdersPage() {
         }
 
         // Resolve agent names for orders that don't already have one
-        const uniqueUserIds = [...new Set(
-          normalized.filter(o => o.agentName === '—' && o.userId).map(o => o.userId)
-        )];
+        const ordersNeedingName = normalized.filter(o => o.agentName === '—' && o.userId);
+        const uniqueKeys = [...new Map(ordersNeedingName.map(o => [`${o.ownerType}:${o.userId}`, o])).values()];
 
-        if (uniqueUserIds.length > 0) {
+        if (uniqueKeys.length > 0) {
           const nameMap = Object.fromEntries(
-            await Promise.all(uniqueUserIds.map(async id => [id, await fetchUserName(id)]))
+            await Promise.all(uniqueKeys.map(async o => [
+              `${o.ownerType}:${o.userId}`,
+              await fetchUserName(o.userId, o.ownerType)
+            ]))
           );
           setOrders(normalized.map(o =>
-            o.agentName === '—' && nameMap[o.userId]
-              ? { ...o, agentName: nameMap[o.userId] }
+            o.agentName === '—' && nameMap[`${o.ownerType}:${o.userId}`]
+              ? { ...o, agentName: nameMap[`${o.ownerType}:${o.userId}`] }
               : o
           ));
         } else {

--- a/src/utils/orders/orderModel.js
+++ b/src/utils/orders/orderModel.js
@@ -35,6 +35,7 @@ export function normalizeOrder(raw) {
   return {
     id: raw.id ?? raw.order_id,
     userId: raw.user_id ?? raw.userId,
+    ownerType: raw.owner_type ?? raw.ownerType ?? null,
     agentName: raw.agent_name ?? raw.agentName ?? '—',
     assetId: raw.asset_id ?? raw.assetId,
     assetName: raw.asset_name ?? raw.assetName ?? raw.listing_name ?? '—',


### PR DESCRIPTION
…y state

- SupervisorOrdersPage: resolve agent name from /actuaries for ACTUARY orders, /clients for CLIENT orders
- orderModel: add ownerType field to normalizeOrder
- orders.js: fetchUserName accepts ownerType param, uses correct endpoint per role
- accounts.js: add getBankAccounts() with AccountType=bank AND CompanyID=1 filter
- ClientSecurities/SellOrderModal: use getBankAccounts() for employees, show empty state message