### PR TITLE
Povezivanje apija sa endpointovima

### DIFF
--- a/src/api/endpoints/investmentFunds.js
+++ b/src/api/endpoints/investmentFunds.js
@@ -5,7 +5,7 @@ export const investmentFundsApi = {
     tradingApi.post('/investment-funds', payload),
 
   getFunds: (params = {}) =>
-    tradingApi.get('/investment-funds', { params }),
+    tradingApi.get('/funds', { params }),
 
   getFundDetails: (fundId) =>
     tradingApi.get(`/investment-funds/${fundId}`),
@@ -16,8 +16,8 @@ export const investmentFundsApi = {
   getFundPerformance: (fundId, range = 'monthly') =>
     tradingApi.get(`/investment-funds/${fundId}/performance`, { params: { range } }),
 
-  getManagedFunds: () =>
-    tradingApi.get('/me/funds'),
+  getManagedFunds: (actuaryId) =>
+    tradingApi.get(`/actuary/${actuaryId}/assets/funds`),
 
   depositToFund: (fundId, payload) =>
     tradingApi.post(`/investment-funds/${fundId}/deposit`, payload),
@@ -32,7 +32,7 @@ export const investmentFundsApi = {
     tradingApi.post(`/investment-funds/${fundId}/assets/${assetId}/sell`, payload),
 
   getActuaryPerformances: () =>
-    tradingApi.get('/profit-bank/actuaries'),
+    tradingApi.get('/profit/actuaries'),
 
   getActuaryProfit: (actuaryId) =>
     tradingApi.get(`/actuary/${actuaryId}/assets/profit`),

--- a/src/api/endpoints/investmentFunds.js
+++ b/src/api/endpoints/investmentFunds.js
@@ -16,6 +16,9 @@ export const investmentFundsApi = {
   getFundPerformance: (fundId, range = 'monthly') =>
     tradingApi.get(`/investment-funds/${fundId}/performance`, { params: { range } }),
 
+  getFundPositions: () =>
+    tradingApi.get('/profit/funds'),
+
   getManagedFunds: (actuaryId) =>
     tradingApi.get(`/actuary/${actuaryId}/assets/funds`),
 

--- a/src/api/endpoints/securities.js
+++ b/src/api/endpoints/securities.js
@@ -237,14 +237,16 @@ export const securitiesApi = {
   buy(data) {
     return api.post('/orders', {
       account_number: data.accountNumber,
-      listing_id:     data.listingId,
-      direction:      'BUY',
-      order_type:     data.orderType ?? 'MARKET',
-      quantity:       data.quantity,
-      all_or_none:    data.allOrNone ?? false,
-      margin:         data.margin ?? false,
-      limit_value:    data.limitValue ?? 0,
-      stop_value:     data.stopValue  ?? 0,
+      listing_id: data.listingId,
+      direction: 'BUY',
+      order_type: data.orderType ?? 'MARKET',
+      quantity: data.quantity,
+      all_or_none: data.allOrNone ?? false,
+      margin: data.margin ?? false,
+      limit_value: data.limitValue ?? 0,
+      stop_value: data.stopValue ?? 0,
+      purchase_context: data.purchaseContext ?? 'STANDARD',
+      fund_id: data.fundId ?? null,
     });
   },
 

--- a/src/api/endpoints/securities.js
+++ b/src/api/endpoints/securities.js
@@ -235,6 +235,20 @@ export const securitiesApi = {
   },
 
   buy(data) {
+    if (data.fundId) {
+      return api.post('/orders/invest', {
+        fund_id: data.fundId,
+        listing_id: data.listingId,
+        direction: 'BUY',
+        order_type: data.orderType ?? 'MARKET',
+        quantity: data.quantity,
+        all_or_none: data.allOrNone ?? false,
+        margin: data.margin ?? false,
+        limit_value: data.limitValue ?? 0,
+        stop_value: data.stopValue ?? 0,
+      });
+    }
+
     return api.post('/orders', {
       account_number: data.accountNumber,
       listing_id: data.listingId,
@@ -245,22 +259,34 @@ export const securitiesApi = {
       margin: data.margin ?? false,
       limit_value: data.limitValue ?? 0,
       stop_value: data.stopValue ?? 0,
-      purchase_context: data.purchaseContext ?? 'STANDARD',
-      fund_id: data.fundId ?? null,
     });
   },
 
   sell(data) {
+    if (data.fundId) {
+      return api.post('/orders/invest', {
+        fund_id: data.fundId,
+        listing_id: data.listingId,
+        direction: 'SELL',
+        order_type: data.orderType ?? 'MARKET',
+        quantity: data.quantity,
+        all_or_none: data.allOrNone ?? false,
+        margin: data.margin ?? false,
+        limit_value: data.limitValue ?? 0,
+        stop_value: data.stopValue ?? 0,
+      });
+    }
+
     return api.post('/orders', {
       account_number: data.accountNumber,
-      listing_id:     data.listingId,
-      direction:      'SELL',
-      order_type:     data.orderType ?? 'MARKET',
-      quantity:       data.quantity,
-      all_or_none:    data.allOrNone ?? false,
-      margin:         data.margin ?? false,
-      limit_value:    data.limitValue ?? 0,
-      stop_value:     data.stopValue  ?? 0,
+      listing_id: data.listingId,
+      direction: 'SELL',
+      order_type: data.orderType ?? 'MARKET',
+      quantity: data.quantity,
+      all_or_none: data.allOrNone ?? false,
+      margin: data.margin ?? false,
+      limit_value: data.limitValue ?? 0,
+      stop_value: data.stopValue ?? 0,
     });
-  },
+  }
 };

--- a/src/pages/profit-bank/ProfitBankPage.jsx
+++ b/src/pages/profit-bank/ProfitBankPage.jsx
@@ -7,6 +7,7 @@ import { investmentFundsApi } from '../../api/endpoints/investmentFunds';
 import { accountsApi } from '../../api/endpoints/accounts';
 import { portfolioApi } from '../../api/endpoints/portfolio';
 import styles from './ProfitBankPage.module.css';
+import { useAuthStore } from '../../store/authStore';
 
 const TAB = {
   ACTUARIES: 'ACTUARIES',
@@ -61,12 +62,14 @@ export default function ProfitBankPage() {
     refetch: refetchActuaries,
   } = useFetch(() => investmentFundsApi.getActuaryPerformances(), []);
 
+  const userId = useAuthStore(s => s.user?.employee_id ?? s.user?.id);
+
   const {
     data: fundsResponse,
     loading: fundsLoading,
     error: fundsError,
     refetch: refetchFunds,
-  } = useFetch(() => investmentFundsApi.getFunds({ managed_only: true }), []);
+  } = useFetch(() => investmentFundsApi.getManagedFunds(userId), [userId]);
 
   const {
     data: selectedFundResponse,
@@ -86,7 +89,10 @@ export default function ProfitBankPage() {
   const {
     data: actuaryPortfolioResponse,
     loading: actuaryPortfolioLoading,
-  } = useFetch(() => portfolioApi.getActuaryPortfolio(), []);
+  } = useFetch(
+    () => (userId ? portfolioApi.getActuaryPortfolio(userId) : Promise.resolve([])),
+    [userId]
+  );
 
   const actuaries = useMemo(() => {
     const raw = Array.isArray(actuariesResponse)
@@ -196,15 +202,15 @@ export default function ProfitBankPage() {
     try {
       if (modalState.type === ACTION.DEPOSIT) {
         await investmentFundsApi.depositToFund(fund.fund_id, {
-          bank_account_number: form.bankAccountNumber,
-          amount_rsd: amount,
+          account_number: form.bankAccountNumber,
+          amount,
         });
 
         setFeedback({ type: 'uspeh', text: 'Uplata u fond je uspešno evidentirana.' });
       } else {
         await investmentFundsApi.withdrawFromFund(fund.fund_id, {
-          bank_account_number: form.bankAccountNumber,
-          amount_rsd: amount,
+          account_number: form.bankAccountNumber,
+          amount,
         });
 
         setFeedback({ type: 'uspeh', text: 'Povlačenje iz fonda je uspešno evidentirano.' });
@@ -436,11 +442,13 @@ export default function ProfitBankPage() {
                             </button>
                           </td>
                           <td>
-                            {fund.manager?.first_name} {fund.manager?.last_name}
+                            {fund.manager
+                              ? `${fund.manager.first_name ?? ''} ${fund.manager.last_name ?? ''}`.trim()
+                              : '—'}
                           </td>
-                          <td>{formatPercent(fund.bank_share_percent)}</td>
-                          <td>{formatRSD(fund.bank_share_rsd)}</td>
-                          <td>{formatRSD(fund.profit_rsd)}</td>
+                          <td>{formatPercent(fund.bank_share_percent ?? null)}</td>
+                          <td>{formatRSD(fund.bank_share_rsd ?? fund.fund_value ?? 0)}</td>
+                          <td>{formatRSD(fund.profit_rsd ?? 0)}</td>
                           <td>
                             <div className={styles.actionRow}>
                               <button
@@ -507,7 +515,7 @@ export default function ProfitBankPage() {
                   <InfoCard label="Udeo banke (%)" value={formatPercent(selectedFund.bank_share_percent)} />
                   <InfoCard label="Udeo banke (RSD)" value={formatRSD(selectedFund.bank_share_rsd)} />
                   <InfoCard label="Profit u RSD" value={formatRSD(selectedFund.profit_rsd)} />
-                  <InfoCard label="Dostupna likvidnost" value={formatRSD(selectedFund.liquidity_rsd)} />
+                  <InfoCard label="Dostupna likvidnost" value={formatRSD(selectedFund.liquidity_rsd ?? selectedFund.liquid_assets)}/>
                   <InfoCard label="Opis" value={selectedFund.description || '—'} />
                 </div>
 
@@ -516,10 +524,10 @@ export default function ProfitBankPage() {
                 <div className={styles.accountsBlock}>
                   <h3 className={styles.subTitle}>Bankovni račun fonda</h3>
 
-                  {selectedFund.fund_account ? (
+                  {selectedFund.fund_account || selectedFund.account_number ? (
                     <div className={styles.accountItem}>
-                      <strong>{selectedFund.fund_account.name || 'Račun fonda'}</strong>
-                      <span>{selectedFund.fund_account.account_number}</span>
+                      <strong>{selectedFund.fund_account?.name || 'Račun fonda'}</strong>
+                      <span>{selectedFund.fund_account?.account_number || selectedFund.account_number}</span>
                     </div>
                   ) : (
                     <div className={styles.accountItem}>

--- a/src/pages/profit-bank/ProfitBankPage.jsx
+++ b/src/pages/profit-bank/ProfitBankPage.jsx
@@ -69,7 +69,7 @@ export default function ProfitBankPage() {
     loading: fundsLoading,
     error: fundsError,
     refetch: refetchFunds,
-  } = useFetch(() => investmentFundsApi.getManagedFunds(userId), [userId]);
+  } = useFetch(() => investmentFundsApi.getFundPositions(), []);
 
   const {
     data: selectedFundResponse,
@@ -190,8 +190,7 @@ export default function ProfitBankPage() {
 
     if (
       modalState.type === ACTION.WITHDRAW &&
-      amount > Number(fund?.liquidity_rsd ?? fund?.available_liquidity_rsd ?? 0)
-    ) {
+      amount > Number(fund?.liquidity_rsd ?? fund?.available_liquidity_rsd ?? fund?.liquid_assets ?? 0)) {
       setFeedback({
         type: 'greska',
         text: 'Fond nema dovoljno raspoložive likvidnosti.',
@@ -438,17 +437,15 @@ export default function ProfitBankPage() {
                               className={styles.linkButton}
                               onClick={() => setSelectedFundId(fund.fund_id)}
                             >
-                              {fund.name}
+                              {fund.fund_name}
                             </button>
                           </td>
                           <td>
-                            {fund.manager
-                              ? `${fund.manager.first_name ?? ''} ${fund.manager.last_name ?? ''}`.trim()
-                              : '—'}
+                            {fund.manager_name ?? '—'}
                           </td>
-                          <td>{formatPercent(fund.bank_share_percent ?? null)}</td>
-                          <td>{formatRSD(fund.bank_share_rsd ?? fund.fund_value ?? 0)}</td>
-                          <td>{formatRSD(fund.profit_rsd ?? 0)}</td>
+                          <td>{formatPercent(fund.bank_share_pct)}</td>
+                          <td>{formatRSD(fund.bank_share_value)}</td>
+                          <td>{formatRSD(fund.profit)}</td>
                           <td>
                             <div className={styles.actionRow}>
                               <button
@@ -570,7 +567,7 @@ export default function ProfitBankPage() {
                   {modalState.type === ACTION.DEPOSIT ? 'Uplata u fond' : 'Povlačenje iz fonda'}
                 </h3>
                 <p className={styles.modalText}>
-                  Fond: <strong>{modalState.fund?.name}</strong>
+                  Fond: <strong>{modalState.fund?.name ?? modalState.fund?.fund_name ?? '—'}</strong>
                 </p>
               </div>
 
@@ -643,6 +640,7 @@ export default function ProfitBankPage() {
                   {formatRSD(
                     modalState.fund?.liquidity_rsd ??
                     modalState.fund?.available_liquidity_rsd ??
+                    modalState.fund?.liquid_assets ??
                     0
                   )}
                 </div>


### PR DESCRIPTION
Povezala sam funds api sa endpointovima koje je back definisao u swaggeru, i prepravila profit banke stranicu da ih koristi kako treba. Dodala sam dva argumenta koji fale u securities api za buy, kada se kupuje u ime fonda ili banke. 

Jos uvek fale par funkcionalnosti sa backa: 
- da se kroz auth dobije dal je user supervizor ili agent, nemam dobar nacin da resim to na frontu
- kompletni podaci za fund positions (manager, bank share %, bank share RSD, profit RSD)
- potpuna podrška za buy order u ime fonda (fund_id / fund context)
