### PR TITLE
fix: fetch tax from accumulated-tax endpoint in portfolio

### DIFF
--- a/src/features/portfolio/TaxSummary.jsx
+++ b/src/features/portfolio/TaxSummary.jsx
@@ -1,19 +1,13 @@
 import styles from './TaxSummary.module.css';
 
-// DODAJ 'default' OVDE:
-export default function TaxSummary({ stats }) {
-  if (!stats) return null;
+export default function TaxSummary({ totalTax }) {
+  if (totalTax == null) return null;
 
   return (
     <div className={styles.taxWrapper}>
       <div className={styles.taxItem}>
-        <span className={styles.label}>Plaćen porez (2026)</span>
-        <span className={styles.paid}>{stats.taxPaid?.toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</span>
-      </div>
-      <div className={styles.divider} />
-      <div className={styles.taxItem}>
-        <span className={styles.label}>Neplaćen porez (Mart)</span>
-        <span className={styles.unpaid}>{stats.taxUnpaid?.toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</span>
+        <span className={styles.label}>Akumuliran porez</span>
+        <span className={styles.paid}>{totalTax.toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</span>
       </div>
     </div>
   );

--- a/src/pages/admin/PortfolioPage.jsx
+++ b/src/pages/admin/PortfolioPage.jsx
@@ -8,6 +8,7 @@ import ProfitSummary from '../../features/portfolio/ProfitSummary';
 import TaxSummary from '../../features/portfolio/TaxSummary';
 import OptionsSection from '../../features/portfolio/OptionsSection';
 import { portfolioApi } from '../../api/endpoints/portfolio';
+import { taxApi } from '../../api/endpoints/tax';
 import SellOrderModal from '../../features/portfolio/SellOrderModal';
 import styles from './PortfolioPage.module.css';
 
@@ -19,11 +20,8 @@ export default function PortfolioPage() {
   const initFromStorage = useAuthStore(s => s.initFromStorage);
 
   // --- ISPRAVLJEN STATE (Počinjemo sa praznim podacima) ---
-  const [data, setData] = useState({
-    stocks: [],
-    options: [],
-    tax: { taxPaid: 0, taxUnpaid: 0 }
-  });
+  const [data, setData] = useState({ stocks: [], options: [] });
+  const [totalTax, setTotalTax] = useState(null);
   const [, setLoading] = useState(false);
   const [sellModal, setSellModal] = useState(null);
 
@@ -44,30 +42,29 @@ export default function PortfolioPage() {
 
       try {
         setLoading(true);
-        let res;
-        
-        // Dinamički biramo endpoint: Actuary/Agent ili običan Client
-        if (isAgent) {
-          res = await portfolioApi.getActuaryPortfolio(user.id);
-        } else {
-          res = await portfolioApi.getClientPortfolio(user.id);
-        }
+        const [res, taxRes] = await Promise.all([
+          isAgent
+            ? portfolioApi.getActuaryPortfolio(user.id)
+            : portfolioApi.getClientPortfolio(user.id),
+          isAgent
+            ? taxApi.getActuaryTax(user.id)
+            : taxApi.getClientTax(user.id),
+        ]);
 
-        // Tvoj client.js verovatno već vraća res.data kroz interceptor, 
-        // ali za svaki slučaj radimo proveru formata:
-        const rawData = res?.data || res; 
+        const rawData = res?.data || res;
         const allAssets = Array.isArray(rawData) ? rawData : (rawData?.assets || []);
-        
+
         setData({
           stocks: allAssets.filter(a => a.type?.toUpperCase() !== 'OPTION'),
           options: allAssets.filter(a => a.type?.toUpperCase() === 'OPTION'),
-          tax: rawData?.tax || { taxPaid: 0, taxUnpaid: 0 }
         });
+        const taxData = taxRes?.data || taxRes;
+        setTotalTax(taxData?.totalTax ?? 0);
 
       } catch (err) {
         console.error("API Error na portu 8082:", err);
         // Resetujemo state na prazno u slučaju greške da UI ne bi "pukao"
-        setData({ stocks: [], options: [], tax: { taxPaid: 0, taxUnpaid: 0 } });
+        setData({ stocks: [], options: [] });
       } finally {
         setLoading(false);
       }
@@ -109,8 +106,7 @@ export default function PortfolioPage() {
               <h1 className={styles.pageTitle}>Moj Portfolio</h1>
               <p className={styles.pageDesc}>Pregled akcija i finansijskih instrumenata.</p>
             </div>
-            {/* Koristi data.tax */}
-            <TaxSummary stats={data.tax} />
+            <TaxSummary totalTax={totalTax} />
           </div>
         </div>
 

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef, useLayoutEffect } from 'react';
 import gsap from 'gsap';
 import { useAuthStore } from '../../store/authStore';
 import { portfolioApi } from '../../api/endpoints/portfolio';
+import { taxApi } from '../../api/endpoints/tax';
 import ClientHeader from '../../components/layout/ClientHeader';
 import PortfolioTable from '../../features/portfolio/PortfolioTable';
 import SellOrderModal from '../../features/portfolio/SellOrderModal';
@@ -14,7 +15,8 @@ import styles from './ClientPortfolioPage.module.css';
 export default function ClientPortfolioPage() {
   const pageRef = useRef(null);
 
-  const [portfolio, setPortfolio] = useState({ stocks: [], tax: { taxPaid: 0, taxUnpaid: 0 } });
+  const [portfolio, setPortfolio] = useState({ stocks: [] });
+  const [totalTax, setTotalTax] = useState(null);
   const [loading, setLoading]     = useState(true);
   const [error, setError]         = useState(null);
   const [sellModal, setSellModal] = useState(null);
@@ -33,13 +35,15 @@ export default function ClientPortfolioPage() {
         setLoading(true);
         setError(null);
         const clientId = user.client_id ?? user.id;
-        const res = await portfolioApi.getClientPortfolio(clientId);
+        const [res, taxRes] = await Promise.all([
+          portfolioApi.getClientPortfolio(clientId),
+          taxApi.getClientTax(clientId),
+        ]);
         const rawData = res?.data || res;
         const allAssets = Array.isArray(rawData) ? rawData : (rawData?.assets ?? []);
-        setPortfolio({
-          stocks: allAssets.filter(a => a.type?.toUpperCase() !== 'OPTION'),
-          tax: rawData?.tax ?? { taxPaid: 0, taxUnpaid: 0 },
-        });
+        setPortfolio({ stocks: allAssets.filter(a => a.type?.toUpperCase() !== 'OPTION') });
+        const taxData = taxRes?.data || taxRes;
+        setTotalTax(taxData?.totalTax ?? 0);
       } catch (err) {
         console.error('Greška pri učitavanju portfolija:', err);
         setError('Nije moguće učitati podatke portfolija.');
@@ -84,7 +88,7 @@ export default function ClientPortfolioPage() {
               <h1 className={styles.pageTitle}>Moj Portfolio</h1>
               <p className={styles.pageDesc}>Pregled vaših akcija i poresko stanje u realnom vremenu.</p>
             </div>
-            {!loading && !error && <TaxSummary stats={portfolio.tax} />}
+            {!loading && !error && <TaxSummary totalTax={totalTax} />}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Portfolio stranice su čitale `rawData?.tax` iz portfolio API-ja koji to polje ne vraća
- Dodati posebni pozivi na `/client/:clientId/accumulated-tax` i `/actuary/:actId/accumulated-tax`
- `TaxSummary` komponenta ažurirana da prima `totalTax` (broj) umesto `{ taxPaid, taxUnpaid }`