### PR TITLE
fix: endpoint corrections, OTC portal implementation, exercise wiring

### DIFF
--- a/src/api/endpoints/investmentFunds.js
+++ b/src/api/endpoints/investmentFunds.js
@@ -7,47 +7,42 @@ export const investmentFundsApi = {
   getFunds: (params = {}) =>
     tradingApi.get('/funds', { params }),
 
+  getAllFunds: (params = {}) =>
+    tradingApi.get('/funds', { params }),
+
   getFundDetails: (fundId) =>
     tradingApi.get(`/investment-funds/${fundId}`),
 
-  getFundAssets: (fundId) =>
-    tradingApi.get(`/investment-funds/${fundId}/assets`),
+  // POST /investment-funds/{fundId}/invest — klijent ili supervizor ulažu u fond
+  investInFund: (fundId, payload) =>
+    tradingApi.post(`/investment-funds/${fundId}/invest`, payload),
 
-  getFundPerformance: (fundId, range = 'monthly') =>
-    tradingApi.get(`/investment-funds/${fundId}/performance`, { params: { range } }),
-
-  getFundPositions: () =>
-    tradingApi.get('/profit/funds'),
-
-  getManagedFunds: (actuaryId) =>
-    tradingApi.get(`/actuary/${actuaryId}/assets/funds`),
-
-  getClientFunds: (clientId) =>
-    tradingApi.get('/me/funds', { params: clientId ? { client_id: clientId } : undefined }),
-
-  getActuaryFunds: (actuaryId) =>
-    tradingApi.get(`/actuary/${actuaryId}/assets/funds`),
-
+  // Alias za investInFund — koristi se u deposit modalima
   depositToFund: (fundId, payload) =>
-    tradingApi.post(`/investment-funds/${fundId}/deposit`, payload),
+    tradingApi.post(`/investment-funds/${fundId}/invest`, payload),
 
   withdrawFromFund: (fundId, payload) =>
     tradingApi.post(`/investment-funds/${fundId}/withdraw`, payload),
 
-  investInFund: (fundId, payload) =>
-    tradingApi.post(`/investment-funds/${fundId}/invest`, payload),
+  // GET /client/{clientId}/funds — pozicije klijenta u fondovima
+  getClientFunds: (clientId) =>
+    tradingApi.get(`/client/${clientId}/funds`),
 
-  sellFundAsset: (fundId, assetId, payload) =>
-    tradingApi.post(`/investment-funds/${fundId}/assets/${assetId}/sell`, payload),
+  // GET /actuary/{actId}/assets/funds — fondovi kojima upravlja aktuar
+  getActuaryFunds: (actuaryId) =>
+    tradingApi.get(`/actuary/${actuaryId}/assets/funds`),
+
+  getManagedFunds: (actuaryId) =>
+    tradingApi.get(`/actuary/${actuaryId}/assets/funds`),
+
+  getFundsManagedByActuary: (actId) =>
+    tradingApi.get(`/actuary/${actId}/assets/funds`),
+
+  getFundPositions: () =>
+    tradingApi.get('/profit/funds'),
 
   getActuaryPerformances: () =>
     tradingApi.get('/profit/actuaries'),
-
-  getActuaryProfit: (actuaryId) =>
-    tradingApi.get(`/actuary/${actuaryId}/assets/profit`),
-
-  getClientProfit: (clientId) =>
-    tradingApi.get(`/client/${clientId}/assets/profit`),
 
   getProfitActuaries: () =>
     tradingApi.get('/profit/actuaries'),
@@ -55,9 +50,9 @@ export const investmentFundsApi = {
   getProfitFunds: () =>
     tradingApi.get('/profit/funds'),
 
-  getAllFunds: (params = {}) => tradingApi.get('/funds', { params }),
-  getFundDetails: (fundId) => tradingApi.get(`/investment-funds/${fundId}`),
-  investInFund: (fundId, payload) => tradingApi.post(`/investment-funds/${fundId}/invest`, payload),
-  getFundsManagedByActuary: (actId) => tradingApi.get(`/actuary/${actId}/assets/funds`),
+  getActuaryProfit: (actuaryId) =>
+    tradingApi.get(`/actuary/${actuaryId}/assets/profit`),
 
+  getClientProfit: (clientId) =>
+    tradingApi.get(`/client/${clientId}/assets/profit`),
 };

--- a/src/api/endpoints/otc.js
+++ b/src/api/endpoints/otc.js
@@ -1,10 +1,15 @@
 import { tradingApi as api } from '../client';
 
 export const otcApi = {
-  getContracts: () => api.get('/otc/contracts'),
-};
-  getMyNegotiations: ()              => api.get('/otc/offers/active'),
-  acceptOffer:       (offerId, data) => api.patch(`/otc/offers/${offerId}/accept`, data ?? {}),
-  rejectOffer:       (offerId, comment) => api.patch(`/otc/offers/${offerId}/reject`, comment ? { comment } : {}),
-  sendCounterOffer:  (offerId, data) => api.put(`/otc/offers/${offerId}/counter`, data),
+  getPublicListings:   (params = {})          => api.get('/otc/public', { params }),
+  createOffer:         (payload)               => api.post('/otc/offers', payload),
+  getContracts:        ()                      => api.get('/otc/contracts'),
+  getMyNegotiations:   ()                      => api.get('/otc/offers/active'),
+  acceptOffer:         (offerId, data)         => api.patch(`/otc/offers/${offerId}/accept`, data ?? {}),
+  rejectOffer:         (offerId, comment)      => api.patch(`/otc/offers/${offerId}/reject`, comment ? { comment } : {}),
+  sendCounterOffer:    (offerId, data)         => api.put(`/otc/offers/${offerId}/counter`, data),
+  publishActuaryAsset: (actId, ownershipId, amount) =>
+    api.patch(`/actuary/${actId}/assets/${ownershipId}/publish`, { amount }),
+  publishClientAsset:  (clientId, ownershipId, amount) =>
+    api.patch(`/client/${clientId}/assets/${ownershipId}/publish`, { amount }),
 };

--- a/src/api/endpoints/portfolio.js
+++ b/src/api/endpoints/portfolio.js
@@ -1,17 +1,21 @@
-import { tradingApi as api } from '../client'; 
+import { tradingApi as api } from '../client';
 
 export const portfolioApi = {
-  // GET http://rafsi.davidovic.io:8082/api/client/{clientId}/assets
-  // Returns all currently held asset positions for a client
+  // GET /client/{clientId}/assets
   getClientPortfolio: (clientId) => api.get(`/client/${clientId}/assets`),
 
-  // GET http://rafsi.davidovic.io:8082/api/actuary/{actId}/assets
-  // Returns all currently held asset positions for an actuary
+  // GET /actuary/{actId}/assets
   getActuaryPortfolio: (actId) => api.get(`/actuary/${actId}/assets`),
 
-  exerciseOption: (clientId, assetId, accountNumber) =>
-  api.post(`/client/${clientId}/options/${assetId}/exercise`, {
-    account_number: accountNumber,
-  }),
+  // POST /actuary/{actId}/options/{assetId}/exercise
+  exerciseActuaryOption: (actId, assetId, accountNumber) =>
+    api.post(`/actuary/${actId}/options/${assetId}/exercise`, {
+      account_number: accountNumber,
+    }),
 
+  // Backwards-compat alias korišćen u OtcPortalPage — interno poziva actuary endpoint
+  exerciseOption: (actId, assetId, accountNumber) =>
+    api.post(`/actuary/${actId}/options/${assetId}/exercise`, {
+      account_number: accountNumber,
+    }),
 };

--- a/src/api/endpoints/tax.js
+++ b/src/api/endpoints/tax.js
@@ -15,7 +15,3 @@ export const taxApi = {
   getClientTax: (clientId) => api.get(`/client/${clientId}/accumulated-tax`),
 
 };
-export const otcApi = {
-  getPublic: (params = {}) => api.get('/otc/public', { params }),
-  createOffer: (payload) => api.post('/otc/offers', payload),
-};

--- a/src/features/portfolio/OptionsSection.jsx
+++ b/src/features/portfolio/OptionsSection.jsx
@@ -1,81 +1,185 @@
-// src/features/portfolio/OptionsSection.jsx
-import styles from './PortfolioTable.module.css'; // Delimo osnovne stilove tabele
+import { useState, useEffect } from 'react';
+import { portfolioApi } from '../../api/endpoints/portfolio';
+import { accountsApi } from '../../api/endpoints/accounts';
+import styles from './PortfolioTable.module.css';
 
-export default function OptionsSection({ assets = [] }) {
-  
-  // Logika za izvršenje opcije (Exercise)
-  const handleExercise = (id, ticker) => {
-    const potvrda = window.confirm(`Da li ste sigurni da želite da izvršite (exercise) opciju za ${ticker}?`);
-    if (potvrda) {
-      console.log("Pozivanje API-ja za exercise ID:", id);
-      // Ovde ide tvoj api.post(`/portfolio/exercise/${id}`)
-      alert(`Opcija za ${ticker} je uspešno izvršena.`);
+function ExerciseModal({ option, onClose, onSuccess, actId }) {
+  const [accounts, setAccounts]           = useState([]);
+  const [selectedAccount, setSelectedAccount] = useState('');
+  const [loading, setLoading]             = useState(false);
+  const [loadingAccounts, setLoadingAccounts] = useState(true);
+  const [error, setError]                 = useState('');
+
+  useEffect(() => {
+    accountsApi.getBankAccounts()
+      .then(res => {
+        const list = Array.isArray(res) ? res : (res?.data ?? []);
+        setAccounts(list);
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setLoadingAccounts(false));
+  }, []);
+
+  async function handleConfirm() {
+    if (!selectedAccount) { setError('Izaberite račun.'); return; }
+    try {
+      setLoading(true);
+      setError('');
+      await portfolioApi.exerciseActuaryOption(actId, option.id ?? option.asset_id, selectedAccount);
+      onSuccess(option.ticker);
+    } catch (err) {
+      setError(err?.message ?? 'Greška pri iskorišćavanju opcije. Proverite da li je opcija in-the-money.');
+    } finally {
+      setLoading(false);
     }
-  };
-
-  // Pomoćna funkcija za proveru da li je opcija "Active" (nije istekao rok)
-  const isExpired = (settlementDate) => {
-    return new Date() > new Date(settlementDate);
-  };
+  }
 
   return (
-    <div className={styles.tableWrap}>
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>TICKER</th>
-            <th>TIP</th>
-            <th>STRIKE</th>
-            <th>CURRENT</th>
-            <th>SETTLEMENT</th>
-            <th>STATUS</th>
-            <th style={{ textAlign: 'right' }}>AKCIJE</th>
-          </tr>
-        </thead>
-        <tbody>
-          {assets.length === 0 ? (
-            <tr>
-              <td colSpan="7" style={{ textAlign: 'center', padding: '32px', color: 'var(--tx-3)' }}>
-                Trenutno nema dostupnih opcija.
-              </td>
-            </tr>
-          ) : (
-            assets.map((opt) => {
-              const expired = isExpired(opt.settlement);
-              const canExercise = opt.status === 'ITM' && !expired;
+    <div className={styles.modalBackdrop} onClick={onClose}>
+      <div className={styles.modalCard} onClick={e => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div>
+            <h3 className={styles.modalTitle}>Exercise opcije</h3>
+            <p className={styles.modalSubtitle}>{option.ticker} — Strike: ${option.strike}</p>
+          </div>
+          <button className={styles.closeBtn} onClick={onClose}>×</button>
+        </div>
 
-              return (
-                <tr key={opt.id} className={expired ? styles.expiredRow : ''}>
-                  <td className={styles.ticker}>{opt.ticker}</td>
-                  <td className={styles.optionType}>{opt.optionType || 'CALL'}</td>
-                  <td>${opt.strike}</td>
-                  <td>${opt.current || opt.price}</td>
-                  <td className={expired ? styles.neg : ''}>
-                    {opt.settlement} {expired && '(Isteklo)'}
-                  </td>
-                  <td>
-                    <span className={`${styles.badge} ${opt.status === 'ITM' ? styles.itm : styles.otm}`}>
-                      {opt.status}
-                    </span>
-                  </td>
-                  <td style={{ textAlign: 'right' }}>
-                    {canExercise ? (
-                      <button 
-                        className={styles.exerciseBtn}
-                        onClick={() => handleExercise(opt.id, opt.ticker)}
-                      >
-                        EXERCISE
-                      </button>
-                    ) : (
-                      <span className={styles.naText}>N/A</span>
-                    )}
-                  </td>
-                </tr>
-              );
-            })
-          )}
-        </tbody>
-      </table>
+        <div className={styles.modalBody}>
+          <div className={styles.field}>
+            <label>Račun za plaćanje <span style={{ color: 'var(--red, red)' }}>*</span></label>
+            {loadingAccounts ? (
+              <select disabled><option>Učitavanje računa...</option></select>
+            ) : (
+              <select value={selectedAccount} onChange={e => setSelectedAccount(e.target.value)}>
+                <option value="">Izaberite račun...</option>
+                {accounts.map((a, i) => {
+                  const num  = a.AccountNumber ?? a.account_number ?? a.accountNumber ?? a.number ?? '';
+                  const name = a.Name ?? a.name ?? `Račun ${i + 1}`;
+                  const bal  = a.Balance ?? a.balance ?? a.AvailableBalance ?? a.available_balance;
+                  const cur  = a.Currency?.Code ?? a.currency ?? '';
+                  return (
+                    <option key={num || i} value={num}>
+                      {name}{num ? ` — ${num}` : ''}
+                      {bal != null ? ` (${Number(bal).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}${cur ? ` ${cur}` : ''})` : ''}
+                    </option>
+                  );
+                })}
+              </select>
+            )}
+          </div>
+
+          {error && <p className={styles.errorText}>{error}</p>}
+        </div>
+
+        <div className={styles.modalActions}>
+          <button className={styles.cancelBtn ?? styles.btnGhost} onClick={onClose} disabled={loading}>
+            Otkaži
+          </button>
+          <button
+            className={styles.exerciseBtn}
+            onClick={handleConfirm}
+            disabled={loading || !selectedAccount || loadingAccounts}
+          >
+            {loading ? 'Obrada...' : 'Potvrdi Exercise'}
+          </button>
+        </div>
+      </div>
     </div>
+  );
+}
+
+export default function OptionsSection({ assets = [], canExercise, actId }) {
+  const [exerciseModal, setExerciseModal] = useState(null);
+  const [successMsg, setSuccessMsg]       = useState('');
+
+  function isExpired(settlementDate) {
+    return new Date() > new Date(settlementDate);
+  }
+
+  function handleSuccess(ticker) {
+    setExerciseModal(null);
+    setSuccessMsg(`Opcija ${ticker} je uspešno iskorišćena!`);
+    setTimeout(() => setSuccessMsg(''), 4000);
+  }
+
+  return (
+    <>
+      {successMsg && (
+        <div className={styles.successBanner ?? styles.successMsg} style={{ padding: '10px 16px', marginBottom: 12, background: 'var(--green-bg, #0d2b1a)', color: 'var(--green, #4ade80)', borderRadius: 8 }}>
+          ✓ {successMsg}
+        </div>
+      )}
+
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>TICKER</th>
+              <th>TIP</th>
+              <th>STRIKE</th>
+              <th>CURRENT</th>
+              <th>SETTLEMENT</th>
+              <th>STATUS</th>
+              {canExercise && <th style={{ textAlign: 'right' }}>AKCIJE</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {assets.length === 0 ? (
+              <tr>
+                <td colSpan={canExercise ? 7 : 6} style={{ textAlign: 'center', padding: '32px', color: 'var(--tx-3)' }}>
+                  Trenutno nema dostupnih opcija.
+                </td>
+              </tr>
+            ) : (
+              assets.map((opt) => {
+                const expired    = isExpired(opt.settlement);
+                const canExerciseThis = canExercise && opt.status === 'ITM' && !expired;
+
+                return (
+                  <tr key={opt.id ?? opt.asset_id} className={expired ? styles.expiredRow : ''}>
+                    <td className={styles.ticker}>{opt.ticker}</td>
+                    <td>{opt.optionType ?? opt.option_type ?? 'CALL'}</td>
+                    <td>${opt.strike}</td>
+                    <td>${opt.current ?? opt.price}</td>
+                    <td className={expired ? styles.neg : ''}>
+                      {opt.settlement} {expired && '(Isteklo)'}
+                    </td>
+                    <td>
+                      <span className={`${styles.badge} ${opt.status === 'ITM' ? styles.itm : styles.otm}`}>
+                        {opt.status}
+                      </span>
+                    </td>
+                    {canExercise && (
+                      <td style={{ textAlign: 'right' }}>
+                        {canExerciseThis ? (
+                          <button
+                            className={styles.exerciseBtn}
+                            onClick={() => setExerciseModal(opt)}
+                          >
+                            EXERCISE
+                          </button>
+                        ) : (
+                          <span className={styles.naText}>N/A</span>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {exerciseModal && (
+        <ExerciseModal
+          option={exerciseModal}
+          actId={actId}
+          onClose={() => setExerciseModal(null)}
+          onSuccess={handleSuccess}
+        />
+      )}
+    </>
   );
 }

--- a/src/pages/admin/PortfolioPage.jsx
+++ b/src/pages/admin/PortfolioPage.jsx
@@ -10,6 +10,7 @@ import OptionsSection from '../../features/portfolio/OptionsSection';
 import Tabs from '../../features/portfolio/Tabs';
 import SupervisorFundsTab from '../../features/portfolio/SupervisorFundsTab';
 import { portfolioApi } from '../../api/endpoints/portfolio';
+import { otcApi } from '../../api/endpoints/otc';
 import SellOrderModal from '../../features/portfolio/SellOrderModal';
 import styles from './PortfolioPage.module.css';
 
@@ -30,6 +31,8 @@ export default function PortfolioPage() {
   const [, setLoading] = useState(false);
   const [sellModal, setSellModal] = useState(null);
   const [activeTab, setActiveTab] = useState('securities');
+  const [publishLoading, setPublishLoading] = useState(null);
+  const [publishError, setPublishError]     = useState('');
 
   useEffect(() => {
     if (!user) initFromStorage();
@@ -163,7 +166,7 @@ export default function PortfolioPage() {
             {canViewOptions && (
               <div className={`page-anim ${styles.tableCard}`} style={{ marginTop: '32px' }}>
                 <div className={styles.cardHeader}><h3>Opcije i Derivati</h3></div>
-                <OptionsSection assets={data.options} canExercise={canExercise} />
+                <OptionsSection assets={data.options} canExercise={canExercise} actId={employeeId} />
               </div>
             )}
 
@@ -176,6 +179,11 @@ export default function PortfolioPage() {
                       <span className={styles.adminBadge}>ADMIN CONTROL</span>
                    </div>
                 </div>
+                {publishError && (
+                  <div style={{ padding: '8px 24px', color: 'var(--red, red)', fontSize: 13 }}>
+                    {publishError}
+                  </div>
+                )}
                 <div className={styles.tableWrap}>
                   <table className={styles.table}>
                     <thead>
@@ -187,17 +195,42 @@ export default function PortfolioPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {/* Koristi data.stocks */}
-                      {data.stocks.map((asset, idx) => (
-                        <tr key={asset.assetId ?? asset.id ?? `${asset.ticker || 'asset'}-${idx}`}>
-                          <td className={styles.ticker}>{asset.ticker}</td>
-                          <td>{asset.amount}</td>
-                          <td>${asset.price}</td>
-                          <td style={{ textAlign: 'right' }}>
-                            <button className={styles.removeBtn}>Povuci sa portala</button>
-                          </td>
-                        </tr>
-                      ))}
+                      {data.stocks.map((asset, idx) => {
+                        const ownershipId = asset.asset_ownership_id ?? asset.ownershipId ?? asset.assetId ?? asset.id;
+                        const assetKey    = ownershipId ?? `${asset.ticker || 'asset'}-${idx}`;
+                        const isWithdrawing = publishLoading === assetKey;
+                        return (
+                          <tr key={assetKey}>
+                            <td className={styles.ticker}>{asset.ticker}</td>
+                            <td>{asset.public_amount ?? asset.amount}</td>
+                            <td>${asset.price}</td>
+                            <td style={{ textAlign: 'right' }}>
+                              <button
+                                className={styles.removeBtn}
+                                disabled={isWithdrawing}
+                                onClick={async () => {
+                                  if (!ownershipId) return;
+                                  try {
+                                    setPublishError('');
+                                    setPublishLoading(assetKey);
+                                    await otcApi.publishActuaryAsset(employeeId, ownershipId, 0);
+                                    setData(prev => ({
+                                      ...prev,
+                                      stocks: prev.stocks.filter((_, i) => i !== idx),
+                                    }));
+                                  } catch (err) {
+                                    setPublishError(err?.message ?? 'Greška pri povlačenju akcija sa portala.');
+                                  } finally {
+                                    setPublishLoading(null);
+                                  }
+                                }}
+                              >
+                                {isWithdrawing ? 'Povlačenje...' : 'Povuci sa portala'}
+                              </button>
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>

--- a/src/pages/otc/OtcPortalPage.jsx
+++ b/src/pages/otc/OtcPortalPage.jsx
@@ -6,11 +6,12 @@ import { useAuthStore } from '../../store/authStore';
 import { portfolioApi } from '../../api/endpoints/portfolio';
 import { accountsApi } from '../../api/endpoints/accounts';
 import { otcApi } from '../../api/endpoints/otc';
+import OfferModal from './components/OfferModal';
 import styles from './OtcPortalPage.module.css';
 
-
 const TAB = {
-  AKTIVNE: 'AKTIVNE',
+  DOSTUPNE: 'DOSTUPNE',
+  AKTIVNE:  'AKTIVNE',
   SKLOPLJENI: 'SKLOPLJENI',
 };
 
@@ -19,7 +20,12 @@ function isExpired(settlementDate) {
   return new Date(settlementDate) < new Date();
 }
 
-// ─── Confirm Modal ───────────────────────────────────────────────────────────
+function formatDate(dateStr) {
+  if (!dateStr) return '—';
+  return new Date(dateStr).toLocaleDateString('sr-RS');
+}
+
+// ─── Confirm Modal (exercise) ─────────────────────────────────────────────────
 function ConfirmModal({ contract, accounts, selectedAccount, onAccountChange, onConfirm, onClose, loading, error }) {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
@@ -86,7 +92,357 @@ function ConfirmModal({ contract, accounts, selectedAccount, onAccountChange, on
   );
 }
 
-// ─── Tab: Sklopljeni ugovori ─────────────────────────────────────────────────
+// ─── Tab: Dostupne akcije (OTC Portal) ───────────────────────────────────────
+function DostupneAkcije() {
+  const [stocks, setStocks]       = useState([]);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState('');
+  const [offerStock, setOfferStock] = useState(null);
+  const [successMsg, setSuccessMsg] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true);
+        setError('');
+        const res  = await otcApi.getPublicListings();
+        const list = Array.isArray(res) ? res : (res?.data ?? res?.content ?? []);
+        setStocks(list);
+      } catch {
+        setError('Nije moguće učitati dostupne akcije.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  async function handleOfferSubmit(payload) {
+    await otcApi.createOffer({
+      asset_ownership_id:   payload.stockId,
+      amount:               payload.volumeOfStock,
+      price_per_stock:      payload.priceOffer,
+      settlement_date:      payload.settlementDateOffer,
+      premium:              payload.premiumOffer,
+    });
+    setOfferStock(null);
+    setSuccessMsg(`Ponuda za ${payload.stock} je uspešno poslata!`);
+    setTimeout(() => setSuccessMsg(''), 4000);
+  }
+
+  return (
+    <section className={styles.card}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <div className={styles.sectionEyebrow}>OTC Portal</div>
+          <h2 className={styles.sectionTitle}>Dostupne akcije za ponudu</h2>
+        </div>
+      </div>
+
+      {successMsg && (
+        <div className={styles.successBanner}>
+          ✓ {successMsg}
+          <button className={styles.dismissBtn} onClick={() => setSuccessMsg('')}>✕</button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className={styles.loadingState}><Spinner /></div>
+      ) : error ? (
+        <div className={styles.errorBox}>{error}</div>
+      ) : stocks.length === 0 ? (
+        <div className={styles.emptyTable}>Trenutno nema javno dostupnih akcija za OTC trgovanje.</div>
+      ) : (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>TICKER</th>
+                <th>NAZIV</th>
+                <th>VLASNIK</th>
+                <th>DOSTUPNO</th>
+                <th>CENA</th>
+                <th style={{ textAlign: 'right' }}>AKCIJA</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stocks.map((stock, i) => (
+                <tr key={stock.asset_ownership_id ?? stock.id ?? i}>
+                  <td className={styles.ticker}>{stock.ticker ?? '—'}</td>
+                  <td>{stock.name ?? stock.stock_name ?? '—'}</td>
+                  <td>{stock.owner_name ?? '—'}</td>
+                  <td>{stock.public_amount ?? stock.amount ?? '—'}</td>
+                  <td>{stock.price != null ? `$${Number(stock.price).toFixed(2)}` : '—'}</td>
+                  <td style={{ textAlign: 'right' }}>
+                    <button
+                      className={styles.btnPrimary}
+                      onClick={() => setOfferStock(stock)}
+                    >
+                      Pošalji ponudu
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {offerStock && (
+        <OfferModal
+          open={true}
+          stock={offerStock}
+          onClose={() => setOfferStock(null)}
+          onSubmit={handleOfferSubmit}
+        />
+      )}
+    </section>
+  );
+}
+
+// ─── Tab: Aktivne ponude ──────────────────────────────────────────────────────
+function AktivnePonude() {
+  const user = useAuthStore(s => s.user);
+  const [offers, setOffers]               = useState([]);
+  const [loading, setLoading]             = useState(true);
+  const [error, setError]                 = useState('');
+  const [selected, setSelected]           = useState(null);
+  const [modalMode, setModalMode]         = useState('view');
+  const [counterForm, setCounterForm]     = useState({ amount: '', price_per_stock: '', settlement_date: '', premium: '' });
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError]     = useState('');
+  const [actionSuccess, setActionSuccess] = useState('');
+
+  useEffect(() => { loadOffers(); }, []);
+
+  async function loadOffers() {
+    try {
+      setLoading(true);
+      setError('');
+      const res  = await otcApi.getMyNegotiations();
+      const list = Array.isArray(res) ? res : (res?.content ?? res?.data ?? []);
+      setOffers(list);
+    } catch {
+      setError('Greška pri učitavanju aktivnih ponuda.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function openModal(offer) {
+    setSelected(offer);
+    setModalMode('view');
+    setActionError('');
+    setActionSuccess('');
+    setCounterForm({
+      amount:          offer.amount          ?? '',
+      price_per_stock: offer.price_per_stock  ?? '',
+      settlement_date: offer.settlement_date  ? offer.settlement_date.slice(0, 10) : '',
+      premium:         offer.premium          ?? '',
+    });
+  }
+
+  function closeModal() {
+    setSelected(null);
+    setModalMode('view');
+    setActionError('');
+    setActionSuccess('');
+  }
+
+  async function handleAccept() {
+    try {
+      setActionLoading(true);
+      setActionError('');
+      await otcApi.acceptOffer(selected.otc_offer_id);
+      setActionSuccess('Ponuda je uspešno prihvaćena.');
+      await loadOffers();
+      setTimeout(closeModal, 1500);
+    } catch {
+      setActionError('Greška pri prihvatanju ponude.');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleReject() {
+    try {
+      setActionLoading(true);
+      setActionError('');
+      await otcApi.rejectOffer(selected.otc_offer_id);
+      setActionSuccess('Pregovor je uspešno otkazan.');
+      await loadOffers();
+      setTimeout(closeModal, 1500);
+    } catch {
+      setActionError('Greška pri otkazivanju pregovora.');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleCounter() {
+    try {
+      setActionLoading(true);
+      setActionError('');
+      await otcApi.sendCounterOffer(selected.otc_offer_id, {
+        amount:          Number(counterForm.amount),
+        price_per_stock: Number(counterForm.price_per_stock),
+        settlement_date: counterForm.settlement_date,
+        premium:         Number(counterForm.premium),
+      });
+      setActionSuccess('Kontraponuda je uspešno poslata.');
+      await loadOffers();
+      setTimeout(closeModal, 1500);
+    } catch {
+      setActionError('Greška pri slanju kontraponude.');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  function getCounterparty(offer) {
+    if (!user) return '—';
+    const myId = user.id ?? user.sub;
+    if (Number(offer.buyer_id) === Number(myId))  return `Prodavac (ID: ${offer.seller_id})`;
+    if (Number(offer.seller_id) === Number(myId)) return `Kupac (ID: ${offer.buyer_id})`;
+    return `ID: ${offer.buyer_id} / ${offer.seller_id}`;
+  }
+
+  return (
+    <section className={styles.card}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <div className={styles.sectionEyebrow}>OTC Ponude i Ugovori</div>
+          <h2 className={styles.sectionTitle}>Aktivne ponude</h2>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className={styles.loadingState}><Spinner /></div>
+      ) : error ? (
+        <div className={styles.errorBox}>{error}</div>
+      ) : offers.length === 0 ? (
+        <div className={styles.emptyTable}>Nema aktivnih pregovora.</div>
+      ) : (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>STOCK</th>
+                <th>AMOUNT</th>
+                <th>PRICE</th>
+                <th>SETTLEMENT</th>
+                <th>PREMIUM</th>
+                <th>PREGOVARA SA</th>
+                <th style={{ textAlign: 'right' }}>AKCIJE</th>
+              </tr>
+            </thead>
+            <tbody>
+              {offers.map(offer => (
+                <tr key={offer.otc_offer_id} onClick={() => openModal(offer)} style={{ cursor: 'pointer' }}>
+                  <td>#{offer.otc_offer_id}</td>
+                  <td className={styles.ticker}>{offer.ticker ?? offer.stock_name ?? '—'}</td>
+                  <td>{offer.amount ?? '—'}</td>
+                  <td>{offer.price_per_stock != null ? `$${Number(offer.price_per_stock).toFixed(2)}` : '—'}</td>
+                  <td>{formatDate(offer.settlement_date)}</td>
+                  <td>{offer.premium != null ? `$${Number(offer.premium).toFixed(2)}` : '—'}</td>
+                  <td>{getCounterparty(offer)}</td>
+                  <td style={{ textAlign: 'right' }}>
+                    <button className={styles.btnPrimary} onClick={e => { e.stopPropagation(); openModal(offer); }}>
+                      Detalji
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selected && (
+        <div className={styles.modalBackdrop} onClick={closeModal}>
+          <div className={styles.modalCard} onClick={e => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h3 className={styles.modalTitle}>
+                Ponuda #{selected.otc_offer_id} — {selected.ticker ?? selected.stock_name ?? '—'}
+              </h3>
+              <button className={styles.closeIconButton} onClick={closeModal}>×</button>
+            </div>
+
+            <div className={styles.modalBody}>
+              {actionSuccess && <div className={styles.successBanner}>{actionSuccess}</div>}
+              {actionError   && <p className={styles.errorText}>{actionError}</p>}
+
+              {modalMode === 'view' && (
+                <>
+                  <div className={styles.summaryGrid}>
+                    {[
+                      ['Stock',          selected.ticker ?? selected.stock_name ?? '—'],
+                      ['Amount',         selected.amount ?? '—'],
+                      ['Price per stock', selected.price_per_stock != null ? `$${Number(selected.price_per_stock).toFixed(2)}` : '—'],
+                      ['Premium',        selected.premium != null ? `$${Number(selected.premium).toFixed(2)}` : '—'],
+                      ['Settlement',     formatDate(selected.settlement_date)],
+                      ['Status',         selected.status ?? '—'],
+                      ['Pregovara sa',   getCounterparty(selected)],
+                    ].map(([label, value]) => (
+                      <div key={label} className={styles.summaryRow}>
+                        <span className={styles.summaryLabel}>{label}:</span>
+                        <strong>{value}</strong>
+                      </div>
+                    ))}
+                  </div>
+                  <div className={styles.formActions}>
+                    <button className={styles.btnPrimary}  disabled={actionLoading} onClick={handleAccept}>
+                      Prihvati
+                    </button>
+                    <button className={styles.btnGhost}    disabled={actionLoading} onClick={() => setModalMode('counter')}>
+                      Kontraponuda
+                    </button>
+                    <button className={styles.btnDanger ?? styles.btnGhost} disabled={actionLoading} onClick={handleReject}>
+                      Odustani
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {modalMode === 'counter' && (
+                <>
+                  <div className={styles.fieldGrid2 ?? styles.field}>
+                    {[
+                      { key: 'amount',          label: 'Amount',         type: 'number' },
+                      { key: 'price_per_stock', label: 'Price per stock', type: 'number' },
+                      { key: 'settlement_date', label: 'Settlement Date', type: 'date' },
+                      { key: 'premium',         label: 'Premium',         type: 'number' },
+                    ].map(({ key, label, type }) => (
+                      <div key={key} className={styles.field}>
+                        <label>{label}</label>
+                        <input
+                          type={type}
+                          value={counterForm[key]}
+                          onChange={e => setCounterForm(p => ({ ...p, [key]: e.target.value }))}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <div className={styles.formActions}>
+                    <button className={styles.btnPrimary} disabled={actionLoading} onClick={handleCounter}>
+                      Pošalji kontraponudu
+                    </button>
+                    <button className={styles.btnGhost}   disabled={actionLoading} onClick={() => setModalMode('view')}>
+                      Nazad
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ─── Tab: Sklopljeni ugovori ──────────────────────────────────────────────────
 function SklopljeniUgovori() {
   const user = useAuthStore(s => s.user);
   const [options, setOptions]                 = useState([]);
@@ -101,46 +457,34 @@ function SklopljeniUgovori() {
   const [successMsg, setSuccessMsg]           = useState('');
 
   useEffect(() => {
-  async function load() {
-    if (!user?.id) return;
-    try {
-      setLoading(true);
-      setError('');
+    async function load() {
+      if (!user?.id) return;
+      try {
+        setLoading(true);
+        setError('');
 
-      const isEmployee = user?.identity_type === 'employee';
-      const clientId = user?.client_id ?? user?.id;
+        const res = await otcApi.getContracts();
+        const contracts = Array.isArray(res) ? res : (res?.data ?? []);
+        setOptions(contracts);
 
-      const res = await otcApi.getContracts();
-      console.log(res);
-      const contracts = Array.isArray(res) ? res : res?.data ?? [];
-      
-      setOptions(contracts);
-
-      if (isEmployee) {
         const accountsRes = await accountsApi.getBankAccounts().catch(() => []);
         const accs = Array.isArray(accountsRes) ? accountsRes : (accountsRes?.data ?? []);
         setAccounts(accs);
+      } catch {
+        setError('Nije moguće učitati podatke. Pokušajte ponovo.');
+      } finally {
+        setLoading(false);
       }
-
-    } catch (err) {
-      setError('Nije moguće učitati podatke. Pokušajte ponovo.');
-      console.error(err);
-    } finally {
-      setLoading(false);
     }
-  }
-  load();
-}, [user?.id]);
+    load();
+  }, [user?.id]);
 
   const filtered = options.filter(o => {
-  // ❗ SKLONI već iskorišćene ugovore
-  if (o.is_exercised) return false;
-
-  // filtriraj po statusu
-  return filter === 'expired'
-    ? isExpired(o.settlement_date)
-    : !isExpired(o.settlement_date);
-});
+    if (o.is_exercised) return false;
+    return filter === 'expired'
+      ? isExpired(o.settlement_date)
+      : !isExpired(o.settlement_date);
+  });
 
   function openModal(contract) {
     setConfirmModal(contract);
@@ -153,7 +497,7 @@ function SklopljeniUgovori() {
     try {
       setExerciseLoading(true);
       setExerciseError('');
-      await portfolioApi.exerciseOption(user.id, confirmModal.stock_asset_id, selectedAccount)
+      await portfolioApi.exerciseOption(user.id, confirmModal.stock_asset_id, selectedAccount);
       setSuccessMsg(`Opcija ${confirmModal.ticker} je uspešno iskorišćena!`);
       setConfirmModal(null);
       const res = await otcApi.getContracts();
@@ -222,17 +566,13 @@ function SklopljeniUgovori() {
             </thead>
             <tbody>
               {filtered.map(contract => (
-                <tr key={contract.otc_option_contract_id}className={isExpired(contract.settlement_date) ? styles.expiredRow : ''}>
+                <tr key={contract.otc_option_contract_id} className={isExpired(contract.settlement_date) ? styles.expiredRow : ''}>
                   <td className={styles.ticker}>{contract.ticker}</td>
                   <td>{contract.amount}</td>
                   <td>{contract.strike_price}</td>
                   <td>{contract.premium}</td>
-                  <td>
-                    {contract.settlement_date
-                      ? new Date(contract.settlement_date).toLocaleDateString('sr-RS')
-                      : '—'}
-                  </td>
-                  <td>Seller #{contract.seller_id}</td> {/* seller info */}
+                  <td>{formatDate(contract.settlement_date)}</td>
+                  <td>Seller #{contract.seller_id}</td>
                   <td className={contract.profit >= 0 ? styles.pos : styles.neg}>
                     {contract.profit >= 0 ? '+' : ''}
                     {Number(contract.profit ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
@@ -267,25 +607,10 @@ function SklopljeniUgovori() {
   );
 }
 
-// ─── Tab: Aktivne ponude (placeholder za Dušana) ─────────────────────────────
-function AktivnePonude() {
-  return (
-    <section className={styles.card}>
-      <div className={styles.sectionHeader}>
-        <div>
-          <div className={styles.sectionEyebrow}>OTC Ponude i Ugovori</div>
-          <h2 className={styles.sectionTitle}>Aktivne ponude</h2>
-        </div>
-      </div>
-      <div className={styles.emptyTable}>Aktivne ponude su u izradi.</div>
-    </section>
-  );
-}
-
-// ─── Main Page ───────────────────────────────────────────────────────────────
+// ─── Main Page ────────────────────────────────────────────────────────────────
 export default function OtcPortalPage() {
   const pageRef = useRef(null);
-  const [activeTab, setActiveTab] = useState(TAB.SKLOPLJENI);
+  const [activeTab, setActiveTab] = useState(TAB.DOSTUPNE);
 
   useLayoutEffect(() => {
     const ctx = gsap.context(() => {
@@ -296,6 +621,12 @@ export default function OtcPortalPage() {
     return () => ctx.revert();
   }, [activeTab]);
 
+  const tabLabel = {
+    [TAB.DOSTUPNE]:   'Dostupne akcije',
+    [TAB.AKTIVNE]:    'Aktivne ponude',
+    [TAB.SKLOPLJENI]: 'Sklopljeni ugovori',
+  };
+
   return (
     <div ref={pageRef} className={styles.stranica}>
       <Navbar />
@@ -305,39 +636,35 @@ export default function OtcPortalPage() {
           <div className={styles.breadcrumb}>
             <span>OTC</span>
             <span className={styles.breadcrumbSep}>›</span>
-            <span className={styles.breadcrumbAktivna}>
-              {activeTab === TAB.AKTIVNE ? 'Aktivne ponude' : 'Sklopljeni ugovori'}
-            </span>
+            <span className={styles.breadcrumbAktivna}>{tabLabel[activeTab]}</span>
           </div>
           <div className={styles.pageHeader}>
             <div>
               <h1 className={styles.pageTitle}>OTC Ponude i Ugovori</h1>
-              <p className={styles.pageDesc}>Pregled aktivnih pregovora i zaključenih opcionih ugovora.</p>
+              <p className={styles.pageDesc}>Pregled dostupnih akcija, aktivnih pregovora i zaključenih opcionih ugovora.</p>
             </div>
           </div>
         </div>
 
         <section className={`page-anim ${styles.tabsCard}`}>
           <div className={styles.tabsRow}>
-            <button
-              type="button"
-              className={`${styles.tabButton} ${activeTab === TAB.AKTIVNE ? styles.tabButtonActive : ''}`}
-              onClick={() => setActiveTab(TAB.AKTIVNE)}
-            >
-              Aktivne ponude
-            </button>
-            <button
-              type="button"
-              className={`${styles.tabButton} ${activeTab === TAB.SKLOPLJENI ? styles.tabButtonActive : ''}`}
-              onClick={() => setActiveTab(TAB.SKLOPLJENI)}
-            >
-              Sklopljeni ugovori
-            </button>
+            {Object.entries(tabLabel).map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                className={`${styles.tabButton} ${activeTab === key ? styles.tabButtonActive : ''}`}
+                onClick={() => setActiveTab(key)}
+              >
+                {label}
+              </button>
+            ))}
           </div>
         </section>
 
         <div className="page-anim">
-          {activeTab === TAB.AKTIVNE ? <AktivnePonude /> : <SklopljeniUgovori />}
+          {activeTab === TAB.DOSTUPNE   && <DostupneAkcije />}
+          {activeTab === TAB.AKTIVNE    && <AktivnePonude />}
+          {activeTab === TAB.SKLOPLJENI && <SklopljeniUgovori />}
         </div>
       </main>
     </div>


### PR DESCRIPTION
- otc.js: fix broken object syntax (4 methods were undefined at runtime), add getPublicListings, createOffer, publishActuaryAsset, publishClientAsset
- tax.js: remove misplaced otcApi export
- investmentFunds.js: fix getClientFunds (/me/funds → /client/{id}/funds), fix depositToFund (/deposit → /invest), remove duplicate method definitions
- portfolio.js: fix exerciseOption to use /actuary endpoint (client path does not exist in API), add exerciseActuaryOption alias
- OtcPortalPage.jsx: add 'Dostupne akcije' tab with /otc/public listing and OfferModal; implement AktivnePonude tab with real getMyNegotiations data, accept/reject/counter-offer modals
- OptionsSection.jsx: wire EXERCISE button to real API call with account selection modal instead of console.log + alert
- PortfolioPage.jsx: wire 'Povuci sa portala' button to publishActuaryAsset endpoint with loading state and error handling; pass actId to OptionsSection