### PR TITLE
Testovi 36-42, 44-45 i bugfixovi

### DIFF
--- a/cypress/e2e/funds/scenario-36-client-withdraw-insufficient-liquidity.cy.ts
+++ b/cypress/e2e/funds/scenario-36-client-withdraw-insufficient-liquidity.cy.ts
@@ -1,0 +1,80 @@
+import { extractFunds, extractAccounts } from '../../support/helpers';
+
+describe('Scenario 36: Klijent povlači novac iz fonda - nedovoljna likvidnost', () => {
+  beforeEach(() => {
+    cy.loginAsClientAna();
+
+    cy.intercept('GET', '**/api/client/*/assets*').as('getPortfolio');
+    cy.intercept('GET', '**/api/client/*/funds*').as('getClientFunds');
+    cy.intercept('GET', '**/api/clients/*/accounts*').as('getAccounts');
+    cy.intercept('POST', '**/api/investment-funds/*/withdraw').as('withdrawFromFund');
+
+    cy.visit('/client/portfolio');
+  });
+
+  it('šalje withdrawal zahtev za Anin fond', () => {
+    cy.wait('@getPortfolio');
+
+    cy.get('main').within(() => {
+      cy.contains('button', 'Moji fondovi').click();
+    });
+
+    cy.wait('@getClientFunds').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const funds = extractFunds(response?.body);
+
+      expect(
+        funds.length,
+        'Ana mora da ima bar jedan fond da bi scenario mogao da se testira.'
+      ).to.be.greaterThan(0);
+
+      cy.wrap(funds[0]).as('targetFund');
+    });
+
+    cy.get('@targetFund').then((fund: any) => {
+      const fundName = fund.fund_name ?? fund.name;
+
+      cy.contains(fundName).should('be.visible');
+      cy.contains(fundName)
+        .closest('[role="button"]')
+        .within(() => {
+          cy.contains('button', 'Povlačenje iz fonda').click();
+        });
+    });
+
+    cy.wait('@getAccounts').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const accounts = extractAccounts(response?.body);
+      const rsdAccount = accounts.find(
+        (acc: any) => String(acc.currency ?? '').toUpperCase() === 'RSD'
+      );
+
+      expect(
+        rsdAccount,
+        'Ana mora da ima bar jedan RSD račun za scenario 36.'
+      ).to.exist;
+
+      cy.wrap(rsdAccount).as('targetAccount');
+    });
+
+    cy.get('input[value="partial"]').check({ force: true });
+    cy.get('input[placeholder="Unesite iznos"]').clear().type('2000');
+
+    cy.get('@targetAccount').then((acc: any) => {
+      const accountNumber =
+        acc.account_number ?? acc.accountNumber ?? acc.AccountNumber ?? acc.number;
+
+      cy.get('select').select(String(accountNumber));
+    });
+
+    cy.contains('button', 'Potvrdi povlačenje').click();
+
+    cy.wait('@withdrawFromFund').then(({ request, response }) => {
+      expect([200, 201, 202, 400, 409, 422]).to.include(response?.statusCode);
+      expect(Number(request.body.amount)).to.eq(2000);
+      expect(request.body.account_number).to.exist;
+    });
+  });
+});

--- a/cypress/e2e/funds/scenario-37-client-pays-fee-on-foreign-currency-withdrawal.cy.ts
+++ b/cypress/e2e/funds/scenario-37-client-pays-fee-on-foreign-currency-withdrawal.cy.ts
@@ -1,0 +1,81 @@
+import { extractFunds, extractAccounts } from '../../support/helpers';
+
+describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti', () => {
+  beforeEach(() => {
+    cy.loginAsClientAna();
+
+    cy.intercept('GET', '**/api/client/*/assets*').as('getPortfolio');
+    cy.intercept('GET', '**/api/client/*/funds*').as('getClientFunds');
+    cy.intercept('GET', '**/api/clients/*/accounts*').as('getAccounts');
+    cy.intercept('POST', '**/api/investment-funds/*/withdraw').as('withdrawFromFund');
+
+    cy.visit('/client/portfolio');
+  });
+
+  it('omogućava povlačenje na EUR račun za Anin fond', () => {
+    cy.wait('@getPortfolio');
+
+    cy.get('main').within(() => {
+      cy.contains('button', 'Moji fondovi').click();
+    });
+
+    cy.wait('@getClientFunds').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const funds = extractFunds(response?.body);
+
+      expect(
+        funds.length,
+        'Ana mora da ima bar jedan fond da bi scenario 37 mogao da se testira.'
+      ).to.be.greaterThan(0);
+
+      cy.wrap(funds[0]).as('targetFund');
+    });
+
+    cy.get('@targetFund').then((fund: any) => {
+      const fundName = fund.fund_name ?? fund.name;
+
+      cy.contains(fundName).should('be.visible');
+      cy.contains(fundName)
+        .closest('[role="button"]')
+        .within(() => {
+          cy.contains('button', 'Povlačenje iz fonda').click();
+        });
+    });
+
+    cy.wait('@getAccounts').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const accounts = extractAccounts(response?.body);
+      const eurAccount = accounts.find(
+        (acc: any) => String(acc.currency ?? '').toUpperCase() === 'USD'
+      );
+
+      expect(
+        eurAccount,
+        'Ana mora da ima bar jedan USD račun za scenario 37.'
+      ).to.exist;
+
+      cy.wrap(eurAccount).as('targetAccount');
+    });
+
+    cy.get('input[value="partial"]').check({ force: true });
+    cy.get('input[placeholder="Unesite iznos"]').clear().type('1000');
+
+    cy.get('@targetAccount').then((acc: any) => {
+      const accountNumber =
+        acc.account_number ?? acc.accountNumber ?? acc.AccountNumber ?? acc.number;
+
+      cy.get('select').select(String(accountNumber));
+      cy.get('select').find('option:selected').should('contain.text', 'USD');
+    });
+
+    cy.contains('button', 'Potvrdi povlačenje').click();
+
+    cy.wait('@withdrawFromFund').then(({ request, response }) => {
+      expect([200, 201, 202, 400, 409, 422]).to.include(response?.statusCode);
+      expect(Number(request.body.amount)).to.eq(1000);
+      expect(request.body.account_number).to.exist;
+    });
+  });
+});

--- a/cypress/e2e/funds/scenario-38-supervisor-creates-new-fund.cy.ts
+++ b/cypress/e2e/funds/scenario-38-supervisor-creates-new-fund.cy.ts
@@ -1,0 +1,26 @@
+describe('Scenario 38: Supervizor uspešno kreira novi investicioni fond', () => {
+  it('kreira fond i fond postaje vidljiv na discovery stranici', () => {
+    const uniqueName = `Cypress Fund ${Date.now()}`;
+
+    cy.loginAsAdmin();
+    cy.visit('/investment-funds/new');
+
+    cy.url().should('include', '/investment-funds/new');
+    cy.contains('Kreiranje investicionog fonda').should('be.visible');
+
+    cy.get('input[placeholder="npr. Globalni rast"]').should('be.visible').clear();
+    cy.get('input[placeholder="npr. Globalni rast"]').type(uniqueName);
+
+    cy.get('textarea[placeholder*="Kratki opis"]').should('be.visible').clear();
+    cy.get('textarea[placeholder*="Kratki opis"]').type('Fond kreiran kroz Cypress test.');
+
+    cy.get('input[placeholder="npr. 10000"]').should('be.visible').clear();
+    cy.get('input[placeholder="npr. 10000"]').type('1000');
+
+    cy.contains('button', 'Kreiraj fond').click();
+
+    cy.url().should('include', '/investment-funds');
+    cy.contains('Fond "', { matchCase: false }).should('be.visible');
+    cy.contains(uniqueName).should('be.visible');
+  });
+});

--- a/cypress/e2e/funds/scenario-39-agent-cannot-access-create-fund-page.cy.ts
+++ b/cypress/e2e/funds/scenario-39-agent-cannot-access-create-fund-page.cy.ts
@@ -1,0 +1,34 @@
+describe('Scenario 39: Agent nema pristup stranici za kreiranje fonda', () => {
+  beforeEach(() => {
+    const apiUrl = Cypress.env('API_URL');
+    if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+    cy.request('POST', `${apiUrl}/auth/login`, {
+      email: 'marko@raf.rs',
+      password: 'pass123',
+    }).then((res) => {
+      expect(res.status).to.eq(200);
+
+      const { user, token, refresh_token } = res.body;
+
+      cy.visit('/investment-funds/new', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem('token', token);
+          if (refresh_token) win.localStorage.setItem('refreshToken', refresh_token);
+          else win.localStorage.removeItem('refreshToken');
+          win.localStorage.setItem('user', JSON.stringify(user));
+        },
+      });
+    });
+  });
+
+  it('odbija pristup stranici za kreiranje fonda', () => {
+    cy.url().should('not.include', '/investment-funds/new');
+
+    cy.contains('Kreiranje investicionog fonda').should('not.exist');
+    cy.get('input[placeholder="npr. Globalni rast"]').should('not.exist');
+    cy.get('textarea[placeholder*="Kratki opis"]').should('not.exist');
+    cy.get('input[placeholder="npr. 10000"]').should('not.exist');
+    cy.contains('button', 'Kreiraj fond').should('not.exist');
+  });
+});

--- a/cypress/e2e/funds/scenario-44-supervisor-views-managed-funds.cy.ts
+++ b/cypress/e2e/funds/scenario-44-supervisor-views-managed-funds.cy.ts
@@ -1,0 +1,85 @@
+import { pickArray } from '../../support/helpers';
+
+function loginAsSupervisor() {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  cy.request('POST', `${apiUrl}/auth/login`, {
+    email: 'admin@raf.rs',
+    password: 'admin123',
+  }).then((res) => {
+    expect(res.status).to.eq(200);
+
+    const { user, token, refresh_token } = res.body;
+
+    cy.visit('/portfolio', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('token', token);
+        if (refresh_token) win.localStorage.setItem('refreshToken', refresh_token);
+        else win.localStorage.removeItem('refreshToken');
+        win.localStorage.setItem('user', JSON.stringify(user));
+      },
+    });
+  });
+}
+
+describe('Scenario 44: Supervizor pregleda fondove kojima upravlja', () => {
+  beforeEach(() => {
+    loginAsSupervisor();
+
+    cy.intercept('GET', '**/api/actuary/*/assets/funds*').as('getManagedFunds');
+    cy.intercept('GET', '**/api/**/assets*').as('getPortfolioAssets');
+  });
+
+  it('na tabu "Moji fondovi" vidi fondove koje upravlja sa nazivom, opisom, vrednošću i likvidnošću', () => {
+    cy.wait('@getPortfolioAssets');
+
+    cy.contains(/^Moji fondovi$/i).click();
+
+    cy.wait('@getManagedFunds').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const funds = pickArray(response?.body);
+      expect(funds.length, 'Supervizor treba da ima bar jedan fond kojim upravlja.').to.be.greaterThan(0);
+
+      const fund = funds[0];
+      expect(fund.fund_id ?? fund.id).to.exist;
+      expect(fund.name ?? fund.fund_name).to.exist;
+    });
+
+    cy.contains(/^Moji fondovi$/i).should('be.visible');
+
+    cy.get('@getManagedFunds').then((interception: any) => {
+      const funds = pickArray(interception.response?.body);
+      const firstFund = funds[0];
+
+      const fundName = firstFund.name ?? firstFund.fund_name;
+      const fundDescription = firstFund.description ?? firstFund.fund_description;
+      const fundValue = Number(firstFund.fund_value ?? 0).toLocaleString('sr-RS', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+      const fundLiquidity = Number(
+        firstFund.liquid_assets ??
+        firstFund.available_liquidity_rsd ??
+        firstFund.liquidity_rsd ??
+        0
+      ).toLocaleString('sr-RS', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+
+      cy.contains(fundName).should('be.visible');
+
+      if (fundDescription) {
+        cy.contains(fundDescription).should('be.visible');
+      }
+
+      cy.contains(/vrednost fonda/i).should('be.visible');
+      cy.contains(fundValue.replace(/\s/g, '\\s*'), { matchCase: false }).should('exist');
+
+      cy.contains(/likvidnost/i).should('be.visible');
+      cy.contains(fundLiquidity.replace(/\s/g, '\\s*'), { matchCase: false }).should('exist');
+    });
+  });
+});

--- a/cypress/e2e/funds/scenario-45-client-fund-percentage-changes-after-another-client-invests.cy.ts
+++ b/cypress/e2e/funds/scenario-45-client-fund-percentage-changes-after-another-client-invests.cy.ts
@@ -1,0 +1,215 @@
+const AUTH_API = 'http://rafsi.davidovic.io:8080/api';
+const BANKING_API = 'http://rafsi.davidovic.io:8081/api';
+const TRADING_API = 'http://rafsi.davidovic.io:8082/api';
+
+function pickArray(body: any) {
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.data)) return body.data;
+  if (Array.isArray(body?.content)) return body.content;
+  if (Array.isArray(body?.items)) return body.items;
+  return [];
+}
+
+function loginOnly(email: string, password: string) {
+  return cy.request('POST', `${AUTH_API}/auth/login`, { email, password }).then((res) => {
+    expect(res.status).to.eq(200);
+    return res.body;
+  });
+}
+
+function loginAndVisit(email: string, password: string, path: string) {
+  return loginOnly(email, password).then((body) => {
+    const { user, token, refresh_token } = body;
+
+    cy.visit(path, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('token', token);
+        if (refresh_token) win.localStorage.setItem('refreshToken', refresh_token);
+        else win.localStorage.removeItem('refreshToken');
+        win.localStorage.setItem('user', JSON.stringify(user));
+      },
+    });
+
+    return cy.wrap(body);
+  });
+}
+
+function getClientId(user: any) {
+  return user?.client_id ?? user?.identity_id ?? user?.id;
+}
+
+function getFundId(fund: any) {
+  return fund?.fund_id ?? fund?.id;
+}
+
+function getFundName(fund: any) {
+  return fund?.fund_name ?? fund?.name ?? '';
+}
+
+function getFundPercent(fund: any) {
+  return Number(
+    fund?.clients_share_percent ??
+    fund?.client_share_percentage ??
+    0
+  );
+}
+
+function fetchClientFunds(token: string, clientId: string | number) {
+  return cy.request({
+    method: 'GET',
+    url: `${TRADING_API}/client/${clientId}/funds`,
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+}
+
+function fetchAllBankAccounts(token: string) {
+  return cy.request({
+    method: 'GET',
+    url: `${BANKING_API}/accounts?page=1&page_size=200`,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+function findInternalBankAccount(accounts: any[]) {
+  return accounts.find((a) => {
+    const type = String(a.AccountType ?? a.account_type ?? '').toLowerCase();
+    const companyId = Number(a.CompanyID ?? a.company_id ?? 0);
+    return type === 'bank' && companyId === 1;
+  });
+}
+
+function getAccountNumber(account: any) {
+  return String(
+    account?.AccountNumber ??
+    account?.account_number ??
+    account?.accountNumber ??
+    ''
+  );
+}
+
+function investInFund(token: string, fundId: string | number, accountNumber: string, amount: number) {
+  return cy.request({
+    method: 'POST',
+    url: `${TRADING_API}/investment-funds/${fundId}/invest`,
+    headers: { Authorization: `Bearer ${token}` },
+    body: {
+      account_number: accountNumber,
+      amount,
+    },
+    failOnStatusCode: false,
+  });
+}
+
+describe('Scenario 45: Procenat fonda klijenta se menja kada admin uplati u isti fond', () => {
+  const anaEmail = 'ana.anic@example.com';
+  const anaPassword = 'password123';
+
+  const adminEmail = 'admin@raf.rs';
+  const adminPassword = 'admin123';
+
+  it('procenat klijenta A se smanjuje nakon admin uplate u isti fond', () => {
+    let anaToken = '';
+    let anaClientId: string | number;
+    let adminToken = '';
+
+    let targetFundId: string | number;
+    let targetFundName = '';
+    let percentBefore = 0;
+
+    // 1) Login kao Ana i uzmi Alpha Growth Fund
+    loginOnly(anaEmail, anaPassword).then((body) => {
+      anaToken = body.token;
+      anaClientId = getClientId(body.user);
+
+      expect(anaClientId, 'Ana mora imati client id').to.exist;
+    });
+
+    cy.then(() => fetchClientFunds(anaToken, anaClientId)).then((res) => {
+      expect(res.status).to.eq(200);
+
+      const funds = pickArray(res.body);
+      expect(funds.length, 'Ana mora imati bar jedan fond').to.be.greaterThan(0);
+
+      const alphaFund = funds.find((f: any) => {
+        const name = getFundName(f).toLowerCase();
+        return name.includes('alpha growth fund');
+      });
+
+      expect(alphaFund, 'Ana mora imati Alpha Growth Fund').to.exist;
+
+      targetFundId = getFundId(alphaFund);
+      targetFundName = getFundName(alphaFund);
+      percentBefore = getFundPercent(alphaFund);
+
+      expect(targetFundId, 'Alpha Growth Fund mora imati id').to.exist;
+      expect(percentBefore, 'Početni procenat mora biti > 0').to.be.greaterThan(0);
+    });
+
+    // 2) Login kao admin
+    loginOnly(adminEmail, adminPassword).then((body) => {
+      adminToken = body.token;
+    });
+
+    // 3) Admin ulaže 1000 u isti fond koristeći interni bankovni račun
+    cy.then(() => fetchAllBankAccounts(adminToken)).then((accountsRes) => {
+      expect(accountsRes.status).to.eq(200);
+
+      const bankAccounts = pickArray(accountsRes.body);
+      expect(bankAccounts.length, 'Moraju postojati bankovni računi').to.be.greaterThan(0);
+
+      const bankAccount = findInternalBankAccount(bankAccounts);
+      expect(
+        bankAccount,
+        'Mora postojati interni bankovni račun (AccountType=bank, CompanyID=1)'
+      ).to.exist;
+
+      const accountNumber = getAccountNumber(bankAccount);
+      expect(accountNumber, 'Interni bankovni račun mora imati broj').to.not.equal('');
+
+      return investInFund(adminToken, targetFundId, accountNumber, 2000);
+    }).then((investRes: any) => {
+      expect(
+        [200, 201],
+        `Admin uplata nije uspela: ${JSON.stringify(investRes.body)}`
+      ).to.include(investRes.status);
+    });
+
+    // 4) Poll dok se Ani ne smanji procenat
+    function pollAnaFunds(attempt = 0): Cypress.Chainable {
+      return cy.then(() => fetchClientFunds(anaToken, anaClientId)).then((res) => {
+        expect(res.status).to.eq(200);
+
+        const funds = pickArray(res.body);
+        const updatedFund = funds.find((f: any) => String(getFundId(f)) === String(targetFundId));
+
+        expect(updatedFund, 'Ciljni fond mora postojati kod Ane').to.exist;
+
+        const percentAfter = getFundPercent(updatedFund);
+
+        if (percentAfter < percentBefore) {
+          expect(percentAfter, 'Procenat klijenta A treba da se smanji').to.be.lessThan(percentBefore);
+          return cy.wrap(updatedFund).as('updatedFund');
+        }
+
+        if (attempt >= 8) {
+          throw new Error(`Procenat se nije smanjio. Pre: ${percentBefore}, posle: ${percentAfter}`);
+        }
+
+        cy.wait(1000);
+        return pollAnaFunds(attempt + 1);
+      });
+    }
+
+    pollAnaFunds();
+
+    // 5) UI provera da se fond i dalje vidi Ani
+    loginAndVisit(anaEmail, anaPassword, '/portfolio');
+
+    cy.contains(/^Moji fondovi$/i).click();
+
+    cy.get('@updatedFund').then((fund: any) => {
+      cy.contains(getFundName(fund)).should('be.visible');
+    });
+  });
+});

--- a/cypress/e2e/orders/scenario-40-supervisor-buys-security-for-fund.cy.ts
+++ b/cypress/e2e/orders/scenario-40-supervisor-buys-security-for-fund.cy.ts
@@ -1,0 +1,153 @@
+import { pickArray } from '../../support/helpers';
+
+function loginAsSupervisor() {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  cy.request('POST', `${apiUrl}/auth/login`, {
+    email: 'admin@raf.rs',
+    password: 'admin123',
+  }).then((res) => {
+    expect(res.status).to.eq(200);
+
+    const { user, token, refresh_token } = res.body;
+
+    cy.visit('/securities', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('token', token);
+        if (refresh_token) win.localStorage.setItem('refreshToken', refresh_token);
+        else win.localStorage.removeItem('refreshToken');
+        win.localStorage.setItem('user', JSON.stringify(user));
+      },
+    });
+  });
+}
+
+function selectFirstRealAccountOption() {
+  cy.contains(/^RAČUN ZA KUPOVINU$/i)
+    .parent()
+    .find('select')
+    .should('not.be.disabled');
+
+  cy.wait(500);
+
+  cy.contains(/^RAČUN ZA KUPOVINU$/i)
+    .parent()
+    .find('select option')
+    .then(($options) => {
+      const real = [...$options].find((o) => {
+        const opt = o as HTMLOptionElement;
+        const text = (opt.textContent || '').trim();
+        return opt.value && text !== 'Učitavanje...' && text !== 'Izaberite račun...';
+      });
+
+      expect(real, 'Mora postojati bar jedan stvarni račun u dropdown-u.').to.exist;
+
+      cy.contains(/^RAČUN ZA KUPOVINU$/i)
+        .parent()
+        .find('select')
+        .select((real as HTMLOptionElement).value, { force: true })
+        .blur();
+    });
+}
+
+describe('Scenario 40: Supervizor kupuje hartiju za investicioni fond', () => {
+  beforeEach(() => {
+    loginAsSupervisor();
+
+    cy.intercept('GET', '**/api/listings/stocks*').as('getStocks');
+    cy.intercept('GET', '**/api/accounts*').as('getAccounts');
+    cy.intercept('GET', '**/api/actuary/*/assets/funds*').as('getManagedFunds');
+    cy.intercept('POST', '**/api/orders/invest').as('createFundOrder');
+  });
+
+  it('kreira BUY order za fond i šalje ga preko /orders/invest', () => {
+    cy.wait('@getStocks').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const stocks = pickArray(response?.body);
+      expect(stocks.length).to.be.greaterThan(0);
+
+      const cheapest = [...stocks]
+        .filter((s: any) => Number(s?.price) > 0)
+        .sort((a: any, b: any) => Number(a.price) - Number(b.price))[0];
+
+      expect(cheapest).to.exist;
+      cy.wrap(cheapest).as('targetStock');
+    });
+
+    cy.get('@targetStock').then((stock: any) => {
+      cy.contains('td', stock.ticker)
+        .closest('tr')
+        .within(() => {
+          cy.contains(/kreiraj nalog/i).click();
+        });
+    });
+
+    cy.contains(/^KUPUJEM ZA INVESTICIONI FOND$/i).click();
+
+    cy.wait('@getAccounts').its('response.statusCode').should('eq', 200);
+    cy.wait('@getManagedFunds').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const funds = pickArray(response?.body);
+      expect(funds.length).to.be.greaterThan(0);
+
+      cy.get('@targetStock').then((stock: any) => {
+        const stockPrice = Number(stock.price ?? 0);
+
+        const fund = funds.find((f: any) => {
+          const liquidity = Number(
+            f.liquid_assets ??
+            f.available_liquidity_rsd ??
+            f.liquidity_rsd ??
+            0
+          );
+          return liquidity >= stockPrice;
+        });
+
+        expect(fund, 'Potreban je fond sa dovoljno likvidnosti za 1 komad izabrane hartije.').to.exist;
+        cy.wrap(fund).as('targetFund');
+      });
+    });
+
+    selectFirstRealAccountOption();
+
+    cy.contains(/^INVESTICIONI FOND$/i)
+      .parent()
+      .find('select')
+      .should('not.be.disabled');
+
+    cy.wait(500);
+
+    cy.get('@targetFund').then((fund: any) => {
+      const fundId = String(fund.fund_id ?? fund.id);
+
+      cy.contains(/^INVESTICIONI FOND$/i)
+        .parent()
+        .find('select')
+        .select(fundId, { force: true })
+        .blur();
+    });
+
+    cy.get('input[placeholder="Unesite količinu..."]').clear().type('1');
+
+    cy.contains('button', /^Nastavi$/i)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    cy.contains('button', /^Potvrdi$/i)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    cy.wait('@createFundOrder').then(({ request, response }) => {
+      expect([200, 201]).to.include(response?.statusCode);
+      expect(request.body.direction).to.eq('BUY');
+      expect(request.body.quantity).to.eq(1);
+      expect(request.body.fund_id).to.exist;
+      expect(request.body.listing_id).to.exist;
+    });
+  });
+});

--- a/cypress/e2e/orders/scenario-41-supervisor-buys-security-for-bank.cy.ts
+++ b/cypress/e2e/orders/scenario-41-supervisor-buys-security-for-bank.cy.ts
@@ -1,0 +1,116 @@
+import { pickArray } from '../../support/helpers';
+
+function loginAsSupervisor() {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  cy.request('POST', `${apiUrl}/auth/login`, {
+    email: 'admin@raf.rs',
+    password: 'admin123',
+  }).then((res) => {
+    expect(res.status).to.eq(200);
+
+    const { user, token, refresh_token } = res.body;
+
+    cy.visit('/securities', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('token', token);
+        if (refresh_token) win.localStorage.setItem('refreshToken', refresh_token);
+        else win.localStorage.removeItem('refreshToken');
+        win.localStorage.setItem('user', JSON.stringify(user));
+      },
+    });
+  });
+}
+
+function selectFirstRealAccountOption() {
+  cy.contains(/^RAČUN ZA KUPOVINU$/i)
+    .parent()
+    .find('select')
+    .should('not.be.disabled');
+
+  cy.wait(500);
+
+  cy.contains(/^RAČUN ZA KUPOVINU$/i)
+    .parent()
+    .find('select option')
+    .then(($options) => {
+      const real = [...$options].find((o) => {
+        const opt = o as HTMLOptionElement;
+        const text = (opt.textContent || '').trim();
+        return opt.value && text !== 'Učitavanje...' && text !== 'Izaberite račun...';
+      });
+
+      expect(real, 'Mora postojati bar jedan stvarni račun u dropdown-u.').to.exist;
+
+      cy.contains(/^RAČUN ZA KUPOVINU$/i)
+        .parent()
+        .find('select')
+        .select((real as HTMLOptionElement).value, { force: true })
+        .blur();
+    });
+}
+
+describe('Scenario 41: Supervizor kupuje hartiju za banku', () => {
+  beforeEach(() => {
+    loginAsSupervisor();
+
+    cy.intercept('GET', '**/api/listings/stocks*').as('getStocks');
+    cy.intercept('GET', '**/api/accounts*').as('getAccounts');
+    cy.intercept('POST', '**/api/orders').as('createBankOrder');
+    cy.intercept('POST', '**/api/orders/invest').as('createFundOrder');
+  });
+
+  it('šalje BUY order sa bankinog računa preko običnog /orders endpointa', () => {
+    cy.wait('@getStocks').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const stocks = pickArray(response?.body);
+      expect(stocks.length).to.be.greaterThan(0);
+
+      const cheapest = [...stocks]
+        .filter((s: any) => Number(s?.price) > 0)
+        .sort((a: any, b: any) => Number(a.price) - Number(b.price))[0];
+
+      expect(cheapest).to.exist;
+      cy.wrap(cheapest).as('targetStock');
+    });
+
+    cy.get('@targetStock').then((stock: any) => {
+      cy.contains('td', stock.ticker)
+        .closest('tr')
+        .within(() => {
+          cy.contains(/kreiraj nalog/i).click();
+        });
+    });
+
+    cy.contains(/^KUPUJEM ZA BANKU$/i).click();
+
+    cy.wait('@getAccounts').its('response.statusCode').should('eq', 200);
+
+    selectFirstRealAccountOption();
+
+    cy.get('input[placeholder="Unesite količinu..."]').clear().type('1');
+
+    cy.contains('button', /^Nastavi$/i)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    cy.contains('button', /^Potvrdi$/i)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    cy.wait('@createBankOrder').then(({ request, response }) => {
+      expect([200, 201]).to.include(response?.statusCode);
+      expect(request.body.direction).to.eq('BUY');
+      expect(request.body.quantity).to.eq(1);
+      expect(request.body.account_number).to.exist;
+      expect(request.body.listing_id).to.exist;
+      expect(request.body.fund_id).to.not.exist;
+    });
+
+    cy.get('@createFundOrder.all').should('have.length', 0);
+  });
+});

--- a/cypress/e2e/orders/scenario-42-supervisor-cannot-buy-for-fund-with-insufficient-liquidity.cy.ts
+++ b/cypress/e2e/orders/scenario-42-supervisor-cannot-buy-for-fund-with-insufficient-liquidity.cy.ts
@@ -1,0 +1,147 @@
+import { pickArray } from '../../support/helpers';
+
+function loginAsSupervisor() {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  cy.request('POST', `${apiUrl}/auth/login`, {
+    email: 'admin@raf.rs',
+    password: 'admin123',
+  }).then((res) => {
+    expect(res.status).to.eq(200);
+
+    const { user, token, refresh_token } = res.body;
+
+    cy.visit('/securities', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('token', token);
+        if (refresh_token) win.localStorage.setItem('refreshToken', refresh_token);
+        else win.localStorage.removeItem('refreshToken');
+        win.localStorage.setItem('user', JSON.stringify(user));
+      },
+    });
+  });
+}
+
+function selectFirstRealAccountOption() {
+  cy.contains(/^RAČUN ZA KUPOVINU$/i)
+    .parent()
+    .find('select')
+    .should('not.be.disabled');
+
+  cy.wait(500);
+
+  cy.contains(/^RAČUN ZA KUPOVINU$/i)
+    .parent()
+    .find('select option')
+    .then(($options) => {
+      const real = [...$options].find((o) => {
+        const opt = o as HTMLOptionElement;
+        const text = (opt.textContent || '').trim();
+        return opt.value && text !== 'Učitavanje...' && text !== 'Izaberite račun...';
+      });
+
+      expect(real, 'Mora postojati bar jedan stvarni račun u dropdown-u.').to.exist;
+
+      cy.contains(/^RAČUN ZA KUPOVINU$/i)
+        .parent()
+        .find('select')
+        .select((real as HTMLOptionElement).value, { force: true })
+        .blur();
+    });
+}
+
+describe('Scenario 42: Supervizor ne može kupiti za fond ako nema dovoljno likvidnosti', () => {
+  beforeEach(() => {
+    loginAsSupervisor();
+
+    cy.intercept('GET', '**/api/listings/stocks*').as('getStocks');
+    cy.intercept('GET', '**/api/accounts*').as('getAccounts');
+    cy.intercept('GET', '**/api/actuary/*/assets/funds*').as('getManagedFunds');
+    cy.intercept('POST', '**/api/orders/invest').as('createFundOrder');
+  });
+
+  it('blokira nastavak i prikazuje poruku o nedovoljnoj likvidnosti fonda', () => {
+    cy.wait('@getStocks').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const stocks = pickArray(response?.body);
+      expect(stocks.length).to.be.greaterThan(0);
+
+      const expensive = [...stocks]
+        .filter((s: any) => Number(s?.price) > 0)
+        .sort((a: any, b: any) => Number(b.price) - Number(a.price))[0];
+
+      expect(expensive).to.exist;
+      cy.wrap(expensive).as('targetStock');
+    });
+
+    cy.get('@targetStock').then((stock: any) => {
+      cy.contains('td', stock.ticker)
+        .closest('tr')
+        .within(() => {
+          cy.contains(/kreiraj nalog/i).click();
+        });
+    });
+
+    cy.contains(/^KUPUJEM ZA INVESTICIONI FOND$/i).click();
+
+    cy.wait('@getAccounts').its('response.statusCode').should('eq', 200);
+    cy.wait('@getManagedFunds').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const funds = pickArray(response?.body);
+
+      const fund = funds
+        .map((f: any) => ({
+          ...f,
+          liquidity: Number(
+            f.liquid_assets ??
+            f.available_liquidity_rsd ??
+            f.liquidity_rsd ??
+            0
+          ),
+        }))
+        .filter((f: any) => f.liquidity > 0)
+        .sort((a: any, b: any) => a.liquidity - b.liquidity)[0];
+
+      expect(fund, 'Potreban je bar jedan fond sa pozitivnom likvidnošću.').to.exist;
+      cy.wrap(fund).as('targetFund');
+    });
+
+    selectFirstRealAccountOption();
+
+    cy.contains(/^INVESTICIONI FOND$/i)
+      .parent()
+      .find('select')
+      .should('not.be.disabled');
+
+    cy.wait(500);
+
+    cy.get('@targetFund').then((fund: any) => {
+      const fundId = String(fund.fund_id ?? fund.id);
+
+      cy.contains(/^INVESTICIONI FOND$/i)
+        .parent()
+        .find('select')
+        .select(fundId, { force: true })
+        .blur();
+
+      cy.get('@targetStock').then((stock: any) => {
+        const qty = Math.floor(fund.liquidity / Number(stock.price)) + 1;
+        expect(qty).to.be.greaterThan(0);
+
+        cy.get('input[placeholder="Unesite količinu..."]').clear().type(String(qty));
+      });
+    });
+
+    cy.contains('button', /^Nastavi$/i)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    cy.contains(/Fond nema dovoljno raspoložive likvidnosti/i).should('be.visible');
+    cy.contains('button', /^Potvrdi$/i).should('not.exist');
+    cy.get('@createFundOrder.all').should('have.length', 0);
+  });
+});

--- a/cypress/support/helpers.ts
+++ b/cypress/support/helpers.ts
@@ -132,3 +132,23 @@ export function openBuyModal() {
   cy.wait('@getStockDetails');
   cy.contains('Kupi').click();
 }
+
+export function extractFunds(body: any) {
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.data)) return body.data;
+  if (Array.isArray(body?.data?.data)) return body.data.data;
+  return [];
+}
+
+export function extractAccounts(body: any) {
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.data)) return body.data;
+  return [];
+}
+
+export function pickArray(body: any) {
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.data)) return body.data;
+  if (Array.isArray(body?.content)) return body.content;
+  return [];
+}

--- a/src/features/portfolio/ClientFundsTab.jsx
+++ b/src/features/portfolio/ClientFundsTab.jsx
@@ -7,6 +7,34 @@ import FundDepositModal from './FundDepositModal';
 import FundWithdrawModal from './FundWithdrawModal';
 import styles from './ClientFundsTab.module.css';
 
+function extractFundsResponse(res) {
+  if (Array.isArray(res)) return res;
+  if (Array.isArray(res?.data)) return res.data;
+  if (Array.isArray(res?.data?.data)) return res.data.data;
+  return [];
+}
+
+function normalizeClientFund(fund) {
+  return {
+    fund_id: fund.fund_id,
+    fund_name: fund.fund_name,
+    fund_description: fund.fund_description,
+    clients_share_percent: fund.clients_share_percent,
+    clients_share_value_rsd: fund.clients_share_value_rsd,
+    total_profit: fund.total_profit,
+  };
+}
+
+function formatMoney(value) {
+  if (value == null) return '—';
+  return `${Number(value).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD`;
+}
+
+function formatPercent(value) {
+  if (value == null) return '—';
+  return `${Number(value).toFixed(2)}%`;
+}
+
 export default function ClientFundsTab({ clientId }) {
   const [funds, setFunds] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -15,32 +43,43 @@ export default function ClientFundsTab({ clientId }) {
   const [depositModal, setDepositModal] = useState(null);
   const [withdrawModal, setWithdrawModal] = useState(null);
 
+  async function loadFunds() {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const res = await investmentFundsApi.getClientFunds(clientId);
+      const fundList = extractFundsResponse(res).map(normalizeClientFund);
+      setFunds(fundList);
+    } catch (err) {
+      console.error('Greška pri učitavanju fondova:', err);
+      setError(err?.response?.data?.message || 'Nije moguće učitati podatke fondova.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
   useEffect(() => {
-    const loadFunds = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        // Client-specific endpoint (/me/funds) — backend must provide this
-        const res = await investmentFundsApi.getClientFunds(clientId);
-        const fundList = Array.isArray(res?.data) ? res.data : (res?.data?.data || []);
-        setFunds(fundList);
-
-      } catch (err) {
-        console.error('Greška pri učitavanju fondova:', err);
-        setError(err?.response?.data?.message || 'Nije moguće učitati podatke fondova.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
     if (clientId) {
       loadFunds();
     }
   }, [clientId]);
 
-  if (loading) return <div style={{ padding: '24px' }}><Spinner /></div>;
-  if (error) return <div style={{ padding: '24px' }}><Alert tip="greska" poruka={error} /></div>;
+  if (loading) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <Alert tip="greska" poruka={error} />
+      </div>
+    );
+  }
 
   return (
     <>
@@ -67,8 +106,8 @@ export default function ClientFundsTab({ clientId }) {
               >
                 <div className={styles.fundHeader}>
                   <div>
-                    <h4 className={styles.fundName}>{fund.name}</h4>
-                    <p className={styles.fundDesc}>{fund.description}</p>
+                    <h4 className={styles.fundName}>{fund.fund_name}</h4>
+                    <p className={styles.fundDesc}>{fund.fund_description}</p>
                   </div>
                   <button
                     className={styles.detailsBtn}
@@ -83,27 +122,26 @@ export default function ClientFundsTab({ clientId }) {
 
                 <div className={styles.fundStats}>
                   <div className={styles.statItem}>
-                    <span className={styles.label}>Vrednost fonda:</span>
-                    <span className={styles.value}>
-                      {Number(fund.fund_value ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
-                    </span>
-                  </div>
-                  <div className={styles.statItem}>
                     <span className={styles.label}>Vaš udeo:</span>
                     <span className={styles.value}>
-                      {Number(fund.client_share_value ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+                      {formatMoney(fund.clients_share_value_rsd)}
                     </span>
                   </div>
+
                   <div className={styles.statItem}>
                     <span className={styles.label}>Procenat:</span>
                     <span className={styles.value}>
-                      {Number(fund.client_share_percentage ?? 0).toFixed(2)}%
+                      {formatPercent(fund.clients_share_percent)}
                     </span>
                   </div>
+
                   <div className={styles.statItem}>
                     <span className={styles.label}>Profit:</span>
-                    <span className={`${styles.value} ${(fund.profit ?? 0) >= 0 ? styles.profit : styles.loss}`}>
-                      {(fund.profit ?? 0) >= 0 ? '+' : ''}{Number(fund.profit ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+                    <span
+                      className={`${styles.value} ${(fund.total_profit ?? 0) >= 0 ? styles.profit : styles.loss}`}
+                    >
+                      {(fund.total_profit ?? 0) >= 0 ? '+' : ''}
+                      {formatMoney(fund.total_profit)}
                     </span>
                   </div>
                 </div>
@@ -148,16 +186,6 @@ export default function ClientFundsTab({ clientId }) {
           onClose={() => setDepositModal(null)}
           onSuccess={() => {
             setDepositModal(null);
-            // Refresh funds list
-            const loadFunds = async () => {
-              try {
-                const res = await investmentFundsApi.getClientFunds(clientId);
-                const fundList = Array.isArray(res?.data) ? res.data : (res?.data?.data || []);
-                setFunds(fundList);
-              } catch (err) {
-                console.error('Greška pri osvežavanju fondova:', err);
-              }
-            };
             loadFunds();
           }}
         />
@@ -170,16 +198,6 @@ export default function ClientFundsTab({ clientId }) {
           onClose={() => setWithdrawModal(null)}
           onSuccess={() => {
             setWithdrawModal(null);
-            // Refresh funds list
-            const loadFunds = async () => {
-              try {
-                const res = await investmentFundsApi.getClientFunds(clientId);
-                const fundList = Array.isArray(res?.data) ? res.data : (res?.data?.data || []);
-                setFunds(fundList);
-              } catch (err) {
-                console.error('Greška pri osvežavanju fondova:', err);
-              }
-            };
             loadFunds();
           }}
         />

--- a/src/features/portfolio/FundDepositModal.jsx
+++ b/src/features/portfolio/FundDepositModal.jsx
@@ -4,12 +4,15 @@ import { clientApi } from '../../api/endpoints/client';
 import { accountsApi } from '../../api/endpoints/accounts';
 import styles from './FundDepositModal.module.css';
 
-export default function FundDepositModal({ fund, clientId, actuaryId, isSupervisor = false, onClose, onSuccess }) {
+export default function FundDepositModal({ fund, clientId, isSupervisor = false, onClose, onSuccess }) {
   const [amount, setAmount] = useState('');
   const [accountNumber, setAccountNumber] = useState('');
   const [accounts, setAccounts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  const fundId = fund?.fund_id ?? fund?.id;
+  const fundName = fund?.name ?? fund?.fund_name ?? '';
 
   useEffect(() => {
     const loadAccounts = async () => {
@@ -17,6 +20,7 @@ export default function FundDepositModal({ fund, clientId, actuaryId, isSupervis
         const res = isSupervisor
           ? await accountsApi.getBankAccounts()
           : await clientApi.getAccounts(clientId);
+
         const list = Array.isArray(res) ? res : res?.data ?? [];
         setAccounts(list);
       } catch (err) {
@@ -44,7 +48,12 @@ export default function FundDepositModal({ fund, clientId, actuaryId, isSupervis
   const accountOptions = accounts.map((account, index) => {
     const number = account.account_number ?? account.accountNumber ?? account.AccountNumber ?? account.number ?? '';
     const name = account.name ?? account.Name ?? account.owner_name ?? account.ownerName ?? '';
-    const balance = account.balance ?? account.available_balance ?? account.availableBalance ?? account.Balance ?? account.AvailableBalance;
+    const balance =
+      account.balance ??
+      account.available_balance ??
+      account.availableBalance ??
+      account.Balance ??
+      account.AvailableBalance;
     const currency = account.currency ?? account.Currency?.Code ?? account.Currency ?? '';
     const label = name || number || `Račun ${index + 1}`;
 
@@ -53,29 +62,30 @@ export default function FundDepositModal({ fund, clientId, actuaryId, isSupervis
 
   const handleDeposit = async () => {
     try {
-      if (!amount || parseFloat(amount) <= 0) {
+      const depositAmount = parseFloat(amount);
+
+      if (!depositAmount || depositAmount <= 0) {
         setError('Molimo unesite validan iznos.');
         return;
       }
 
       if (!accountNumber) {
-        setError('Molimo odaberite račun.');
+        setError('Molimo izaberite račun.');
         return;
       }
 
       setLoading(true);
       setError(null);
 
-      const payload = {
+      await investmentFundsApi.depositToFund(fundId, {
         account_number: accountNumber,
-        amount: parseFloat(amount)
-      };
+        amount: depositAmount,
+      });
 
-      await investmentFundsApi.depositToFund(fund.fund_id, payload);
       onSuccess();
     } catch (err) {
-      console.error('Greška pri ulaganju u fond:', err);
-      setError(err.response?.data?.message || 'Greška pri ulaganju. Pokušajte ponovo.');
+      console.error('Greška pri uplati u fond:', err);
+      setError(err?.response?.data?.message || 'Greška pri uplati. Pokušajte ponovo.');
     } finally {
       setLoading(false);
     }
@@ -85,7 +95,7 @@ export default function FundDepositModal({ fund, clientId, actuaryId, isSupervis
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={e => e.stopPropagation()}>
         <div className={styles.header}>
-          <h2 className={styles.title}>Uplata u fond: {fund.name}</h2>
+          <h2 className={styles.title}>Uplata u fond: {fundName}</h2>
           <button className={styles.closeBtn} onClick={onClose}>×</button>
         </div>
 
@@ -98,7 +108,7 @@ export default function FundDepositModal({ fund, clientId, actuaryId, isSupervis
               type="number"
               className={styles.input}
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={e => setAmount(e.target.value)}
               placeholder="Unesite iznos"
               min="0"
               step="0.01"
@@ -108,47 +118,53 @@ export default function FundDepositModal({ fund, clientId, actuaryId, isSupervis
 
           <div className={styles.formGroup}>
             <label className={styles.label}>
-              {isSupervisor ? 'Bankovni račun' : 'Vaš račun'}
+              {isSupervisor ? 'Bankovni račun za uplatu' : 'Račun sa kog se vrši uplata'}
             </label>
             <select
               className={styles.input}
               value={accountNumber}
-              onChange={(e) => setAccountNumber(e.target.value)}
+              onChange={e => setAccountNumber(e.target.value)}
               disabled={loading}
             >
               <option value="">Izaberite račun...</option>
               {accountOptions.map((account, index) => (
                 <option key={account.number || index} value={account.number}>
                   {account.label}{account.label && account.number ? ` — ${account.number}` : ''}
-                  {account.balance != null ? ` (${Number(account.balance).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}${account.currency ? ` ${account.currency}` : ''})` : ''}
+                  {account.balance != null
+                    ? ` (${Number(account.balance).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}${account.currency ? ` ${account.currency}` : ''})`
+                    : ''}
                 </option>
               ))}
             </select>
-            <p className={styles.hint}>
-              Izaberite račun sa kojeg će biti izvršena uplata
-            </p>
           </div>
 
           <div className={styles.infoBox}>
-            <p><strong>Fond:</strong> {fund.name}</p>
-            <p><strong>Minimalna ulaganja:</strong> {Number(fund.minimum_contribution ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</p>
-            <p><strong>Trenutna vrednost:</strong> {Number(fund.fund_value ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</p>
+            <p><strong>Fond:</strong> {fundName}</p>
+            {fund.fund_description && (
+              <p><strong>Opis:</strong> {fund.fund_description}</p>
+            )}
+            {fund.clients_share_value_rsd != null && !isSupervisor && (
+              <p>
+                <strong>Vaš trenutni udeo:</strong>{' '}
+                {Number(fund.clients_share_value_rsd).toLocaleString('sr-RS', {
+                  minimumFractionDigits: 2,
+                })} RSD
+              </p>
+            )}
+            {fund.clients_share_percent != null && !isSupervisor && (
+              <p>
+                <strong>Vaš procenat udela:</strong>{' '}
+                {Number(fund.clients_share_percent).toFixed(2)}%
+              </p>
+            )}
           </div>
         </div>
 
         <div className={styles.footer}>
-          <button
-            className={styles.cancelBtn}
-            onClick={onClose}
-            disabled={loading}
-          >
+          <button className={styles.cancelBtn} onClick={onClose} disabled={loading}>
             Otkaži
           </button>
-          <button
-            className={styles.submitBtn}
-            onClick={handleDeposit}
-            disabled={loading}
-          >
+          <button className={styles.submitBtn} onClick={handleDeposit} disabled={loading}>
             {loading ? 'Obrada...' : 'Potvrdi uplatu'}
           </button>
         </div>

--- a/src/features/portfolio/FundDetailsModal.jsx
+++ b/src/features/portfolio/FundDetailsModal.jsx
@@ -2,7 +2,17 @@ import { useState, useEffect } from 'react';
 import { investmentFundsApi } from '../../api/endpoints/investmentFunds';
 import styles from './FundDetailsModal.module.css';
 
-export default function FundDetailsModal({ fund, isSupervisor = false, onClose }) {
+function formatMoney(value) {
+  if (value == null) return '—';
+  return `${Number(value).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD`;
+}
+
+function formatPercent(value) {
+  if (value == null) return '—';
+  return `${Number(value).toFixed(2)}%`;
+}
+
+export default function FundDetailsModal({ fund, onClose }) {
   const [details, setDetails] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -28,7 +38,7 @@ export default function FundDetailsModal({ fund, isSupervisor = false, onClose }
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={e => e.stopPropagation()}>
         <div className={styles.header}>
-          <h2 className={styles.title}>{fund.name}</h2>
+          <h2 className={styles.title}>{fund.fund_name}</h2>
           <button className={styles.closeBtn} onClick={onClose}>×</button>
         </div>
 
@@ -42,38 +52,35 @@ export default function FundDetailsModal({ fund, isSupervisor = false, onClose }
                 <div className={styles.infoGrid}>
                   <div className={styles.infoItem}>
                     <span className={styles.label}>Naziv:</span>
-                    <span className={styles.value}>{fund.name}</span>
+                    <span className={styles.value}>{fund.fund_name}</span>
                   </div>
+
                   <div className={styles.infoItem}>
                     <span className={styles.label}>Opis:</span>
-                    <span className={styles.value}>{fund.description}</span>
+                    <span className={styles.value}>{fund.fund_description}</span>
                   </div>
+
                   <div className={styles.infoItem}>
-                    <span className={styles.label}>Vrednost fonda:</span>
+                    <span className={styles.label}>Vaš udeo:</span>
                     <span className={styles.value}>
-                      {Number(fund.fund_value ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+                      {formatMoney(fund.clients_share_value_rsd)}
                     </span>
                   </div>
+
                   <div className={styles.infoItem}>
-                    <span className={styles.label}>Minimalna ulaganja:</span>
+                    <span className={styles.label}>Procenat:</span>
                     <span className={styles.value}>
-                      {Number(fund.minimum_contribution ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+                      {formatPercent(fund.clients_share_percent)}
                     </span>
                   </div>
-                  {isSupervisor && (
-                    <div className={styles.infoItem}>
-                      <span className={styles.label}>Likvidnost:</span>
-                      <span className={styles.value}>
-                        {Number(fund.liquid_assets ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
-                      </span>
-                    </div>
-                  )}
-                  {!isSupervisor && (
-                    <div className={styles.infoItem}>
-                      <span className={styles.label}>Vaš udeo (%):</span>
-                      <span className={styles.value}>{Number(fund.client_share_percentage ?? 0).toFixed(2)}%</span>
-                    </div>
-                  )}
+
+                  <div className={styles.infoItem}>
+                    <span className={styles.label}>Profit:</span>
+                    <span className={styles.value}>
+                      {(fund.total_profit ?? 0) >= 0 ? '+' : ''}
+                      {formatMoney(fund.total_profit)}
+                    </span>
+                  </div>
                 </div>
               </div>
 
@@ -83,9 +90,13 @@ export default function FundDetailsModal({ fund, isSupervisor = false, onClose }
                   <div className={styles.assetsList}>
                     {details.assets.map((asset, idx) => (
                       <div key={idx} className={styles.assetItem}>
-                        <span className={styles.assetName}>{asset.name} ({asset.ticker})</span>
+                        <span className={styles.assetName}>
+                          {asset.name} {asset.ticker ? `(${asset.ticker})` : ''}
+                        </span>
                         <span className={styles.assetAmount}>
-                          {Number(asset.amount ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}
+                          {Number(asset.amount ?? 0).toLocaleString('sr-RS', {
+                            minimumFractionDigits: 2,
+                          })}
                         </span>
                       </div>
                     ))}

--- a/src/features/portfolio/FundWithdrawModal.jsx
+++ b/src/features/portfolio/FundWithdrawModal.jsx
@@ -5,12 +5,15 @@ import { accountsApi } from '../../api/endpoints/accounts';
 import styles from './FundWithdrawModal.module.css';
 
 export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervisor = false, onClose, onSuccess }) {
-  const [withdrawType, setWithdrawType] = useState('partial'); // 'partial' or 'full'
+  const [withdrawType, setWithdrawType] = useState('partial');
   const [amount, setAmount] = useState('');
   const [accountNumber, setAccountNumber] = useState('');
   const [accounts, setAccounts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  const fundId = fund?.fund_id ?? fund?.id;
+  const fundName = fund?.name ?? fund?.fund_name ?? '';
 
   useEffect(() => {
     const loadAccounts = async () => {
@@ -18,6 +21,7 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
         const res = isSupervisor
           ? await accountsApi.getBankAccounts()
           : await clientApi.getAccounts(clientId);
+
         const list = Array.isArray(res) ? res : res?.data ?? [];
         setAccounts(list);
       } catch (err) {
@@ -45,19 +49,24 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
   const accountOptions = accounts.map((account, index) => {
     const number = account.account_number ?? account.accountNumber ?? account.AccountNumber ?? account.number ?? '';
     const name = account.name ?? account.Name ?? account.owner_name ?? account.ownerName ?? '';
-    const balance = account.balance ?? account.available_balance ?? account.availableBalance ?? account.Balance ?? account.AvailableBalance;
+    const balance =
+      account.balance ??
+      account.available_balance ??
+      account.availableBalance ??
+      account.Balance ??
+      account.AvailableBalance;
     const currency = account.currency ?? account.Currency?.Code ?? account.Currency ?? '';
     const label = name || number || `Račun ${index + 1}`;
 
     return { number, label, balance, currency };
   });
 
-  const clientShare = fund.client_share_value ?? 0;
+  const clientShare = fund.clients_share_value_rsd ?? 0;
   const fullAmount = isSupervisor ? (fund.liquid_assets ?? 0) : clientShare;
 
   const handleWithdraw = async () => {
     try {
-      let withdrawAmount = withdrawType === 'full' ? fullAmount : parseFloat(amount);
+      const withdrawAmount = withdrawType === 'full' ? fullAmount : parseFloat(amount);
 
       if (!withdrawAmount || withdrawAmount <= 0) {
         setError('Molimo unesite validan iznos.');
@@ -65,7 +74,11 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
       }
 
       if (withdrawAmount > fullAmount) {
-        setError(`Iznos ne može biti veći od dostupnog: ${Number(fullAmount).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD`);
+        setError(
+          `Iznos ne može biti veći od dostupnog: ${Number(fullAmount).toLocaleString('sr-RS', {
+            minimumFractionDigits: 2,
+          })} RSD`
+        );
         return;
       }
 
@@ -79,10 +92,10 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
 
       const payload = {
         account_number: accountNumber,
-        amount: withdrawAmount
+        amount: withdrawAmount,
       };
 
-      await investmentFundsApi.withdrawFromFund(fund.fund_id, payload);
+      await investmentFundsApi.withdrawFromFund(fundId, payload);
       onSuccess();
     } catch (err) {
       console.error('Greška pri povlačenju iz fonda:', err);
@@ -96,7 +109,7 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={e => e.stopPropagation()}>
         <div className={styles.header}>
-          <h2 className={styles.title}>Povlačenje iz fonda: {fund.name}</h2>
+          <h2 className={styles.title}>Povlačenje iz fonda: {fundName}</h2>
           <button className={styles.closeBtn} onClick={onClose}>×</button>
         </div>
 
@@ -115,6 +128,7 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
               />
               <span>Parcijalno povlačenje</span>
             </label>
+
             <label className={styles.radioLabel}>
               <input
                 type="radio"
@@ -124,7 +138,9 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
                 onChange={(e) => setWithdrawType(e.target.value)}
                 disabled={loading}
               />
-              <span>Povuci sve ({Number(fullAmount).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD)</span>
+              <span>
+                Povuci sve ({Number(fullAmount).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD)
+              </span>
             </label>
           </div>
 
@@ -160,36 +176,36 @@ export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervi
               {accountOptions.map((account, index) => (
                 <option key={account.number || index} value={account.number}>
                   {account.label}{account.label && account.number ? ` — ${account.number}` : ''}
-                  {account.balance != null ? ` (${Number(account.balance).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}${account.currency ? ` ${account.currency}` : ''})` : ''}
+                  {account.balance != null
+                    ? ` (${Number(account.balance).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}${account.currency ? ` ${account.currency}` : ''})`
+                    : ''}
                 </option>
               ))}
             </select>
           </div>
 
           <div className={styles.infoBox}>
-            <p><strong>Fond:</strong> {fund.name}</p>
+            <p><strong>Fond:</strong> {fundName}</p>
             {!isSupervisor && (
-              <p><strong>Vaš udeo:</strong> {Number(clientShare).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</p>
+              <p>
+                <strong>Vaš udeo:</strong>{' '}
+                {Number(clientShare).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+              </p>
             )}
             {isSupervisor && (
-              <p><strong>Likvidnost:</strong> {Number(fund.liquid_assets ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD</p>
+              <p>
+                <strong>Likvidnost:</strong>{' '}
+                {Number(fund.liquid_assets ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+              </p>
             )}
           </div>
         </div>
 
         <div className={styles.footer}>
-          <button
-            className={styles.cancelBtn}
-            onClick={onClose}
-            disabled={loading}
-          >
+          <button className={styles.cancelBtn} onClick={onClose} disabled={loading}>
             Otkaži
           </button>
-          <button
-            className={styles.submitBtn}
-            onClick={handleWithdraw}
-            disabled={loading}
-          >
+          <button className={styles.submitBtn} onClick={handleWithdraw} disabled={loading}>
             {loading ? 'Obrada...' : 'Potvrdi povlačenje'}
           </button>
         </div>

--- a/src/features/portfolio/FundWithdrawModal.jsx
+++ b/src/features/portfolio/FundWithdrawModal.jsx
@@ -4,7 +4,7 @@ import { clientApi } from '../../api/endpoints/client';
 import { accountsApi } from '../../api/endpoints/accounts';
 import styles from './FundWithdrawModal.module.css';
 
-export default function FundWithdrawModal({ fund, clientId, actuaryId, isSupervisor = false, onClose, onSuccess }) {
+export default function FundWithdrawModal({ fund, clientId, isSupervisor = false, onClose, onSuccess }) {
   const [withdrawType, setWithdrawType] = useState('partial');
   const [amount, setAmount] = useState('');
   const [accountNumber, setAccountNumber] = useState('');

--- a/src/features/portfolio/SupervisorFundsTab.jsx
+++ b/src/features/portfolio/SupervisorFundsTab.jsx
@@ -7,6 +7,34 @@ import FundDepositModal from './FundDepositModal';
 import FundWithdrawModal from './FundWithdrawModal';
 import styles from './SupervisorFundsTab.module.css';
 
+function extractFundsResponse(res) {
+  if (Array.isArray(res)) return res;
+  if (Array.isArray(res?.data)) return res.data;
+  if (Array.isArray(res?.data?.data)) return res.data.data;
+  return [];
+}
+
+function normalizeSupervisorFund(fund) {
+  return {
+    fund_id: fund.fund_id ?? fund.id,
+    name: fund.name ?? fund.fund_name ?? '',
+    description: fund.description ?? fund.fund_description ?? '',
+    fund_value: fund.fund_value ?? 0,
+    liquid_assets:
+      fund.liquid_assets ??
+      fund.available_liquidity_rsd ??
+      fund.liquidity_rsd ??
+      0,
+    investor_count: fund.investor_count ?? 0,
+    account_number: fund.account_number ?? '',
+  };
+}
+
+function formatMoney(value) {
+  if (value == null) return '—';
+  return `${Number(value).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD`;
+}
+
 export default function SupervisorFundsTab({ actuaryId }) {
   const [funds, setFunds] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -15,29 +43,44 @@ export default function SupervisorFundsTab({ actuaryId }) {
   const [depositModal, setDepositModal] = useState(null);
   const [withdrawModal, setWithdrawModal] = useState(null);
 
-  useEffect(() => {
-    const loadFunds = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const res = await investmentFundsApi.getActuaryFunds(actuaryId);
-        const fundList = Array.isArray(res?.data) ? res.data : (res?.data?.data || []);
-        setFunds(fundList);
-      } catch (err) {
-        console.error('Greška pri učitavanju fondova:', err);
-        setError('Nije moguće učitati podatke fondova.');
-      } finally {
-        setLoading(false);
-      }
-    };
+  async function loadFunds() {
+    try {
+      setLoading(true);
+      setError(null);
 
+      const res = await investmentFundsApi.getActuaryFunds(actuaryId);
+      const fundList = extractFundsResponse(res).map(normalizeSupervisorFund);
+
+      setFunds(fundList);
+    } catch (err) {
+      console.error('Greška pri učitavanju fondova:', err);
+      setError(err?.response?.data?.message || 'Nije moguće učitati podatke fondova.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
     if (actuaryId) {
       loadFunds();
     }
   }, [actuaryId]);
 
-  if (loading) return <div style={{ padding: '24px' }}><Spinner /></div>;
-  if (error) return <div style={{ padding: '24px' }}><Alert tip="greska" poruka={error} /></div>;
+  if (loading) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <Alert tip="greska" poruka={error} />
+      </div>
+    );
+  }
 
   return (
     <>
@@ -82,18 +125,20 @@ export default function SupervisorFundsTab({ actuaryId }) {
                   <div className={styles.statItem}>
                     <span className={styles.label}>Vrednost fonda:</span>
                     <span className={styles.value}>
-                      {Number(fund.fund_value ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+                      {formatMoney(fund.fund_value)}
                     </span>
                   </div>
+
                   <div className={styles.statItem}>
                     <span className={styles.label}>Likvidnost:</span>
                     <span className={styles.value}>
-                      {Number(fund.liquid_assets ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD
+                      {formatMoney(fund.liquid_assets)}
                     </span>
                   </div>
+
                   <div className={styles.statItem}>
                     <span className={styles.label}>Broj klijenta:</span>
-                    <span className={styles.value}>{fund.investor_count ?? 0}</span>
+                    <span className={styles.value}>{fund.investor_count}</span>
                   </div>
                 </div>
 
@@ -139,16 +184,6 @@ export default function SupervisorFundsTab({ actuaryId }) {
           onClose={() => setDepositModal(null)}
           onSuccess={() => {
             setDepositModal(null);
-            // Refresh funds list
-            const loadFunds = async () => {
-              try {
-                const res = await investmentFundsApi.getActuaryFunds(actuaryId);
-                const fundList = Array.isArray(res?.data) ? res.data : (res?.data?.data || []);
-                setFunds(fundList);
-              } catch (err) {
-                console.error('Greška pri osvežavanju fondova:', err);
-              }
-            };
             loadFunds();
           }}
         />
@@ -162,16 +197,6 @@ export default function SupervisorFundsTab({ actuaryId }) {
           onClose={() => setWithdrawModal(null)}
           onSuccess={() => {
             setWithdrawModal(null);
-            // Refresh funds list
-            const loadFunds = async () => {
-              try {
-                const res = await investmentFundsApi.getActuaryFunds(actuaryId);
-                const fundList = Array.isArray(res?.data) ? res.data : (res?.data?.data || []);
-                setFunds(fundList);
-              } catch (err) {
-                console.error('Greška pri osvežavanju fondova:', err);
-              }
-            };
             loadFunds();
           }}
         />

--- a/src/pages/client/ClientSecurities.jsx
+++ b/src/pages/client/ClientSecurities.jsx
@@ -78,11 +78,27 @@ function OrderModal({ security, activeTab, isEmployee, isSupervisor, onClose }) 
   const submittingRef = useRef(false);
 
   const clientId = useAuthStore(s => s.user?.client_id ?? s.user?.id);
+  const actuaryId = useAuthStore(s => s.user?.employee_id ?? s.user?.id);
 
   const { data: accountsData, loading: accountsLoading } = useFetch(
     () => isEmployee ? accountsApi.getBankAccounts() : clientApi.getAccounts(clientId),
     [isEmployee, clientId]
   );
+
+  function normalizeManagedFund(fund) {
+    return {
+      fund_id: fund.fund_id ?? fund.id,
+      name: fund.name ?? fund.fund_name ?? '',
+      description: fund.description ?? fund.fund_description ?? '',
+      account_number: fund.account_number ?? '',
+      fund_value: fund.fund_value ?? 0,
+      liquid_assets:
+        fund.liquid_assets ??
+        fund.available_liquidity_rsd ??
+        fund.liquidity_rsd ??
+        0,
+    };
+  }
 
   const accounts = Array.isArray(accountsData)
     ? accountsData
@@ -94,13 +110,13 @@ function OrderModal({ security, activeTab, isEmployee, isSupervisor, onClose }) 
   );
 
   const { data: managedFundsData, loading: managedFundsLoading } = useFetch(
-    () => isSupervisor ? investmentFundsApi.getManagedFunds() : Promise.resolve([]),
-    [isSupervisor]
+    () => isSupervisor && actuaryId
+      ? investmentFundsApi.getManagedFunds(actuaryId)
+      : Promise.resolve([]),
+    [isSupervisor, actuaryId]
   );
 
-  const managedFunds = Array.isArray(managedFundsData)
-    ? managedFundsData
-    : managedFundsData?.data ?? managedFundsData?.content ?? [];
+  const managedFunds = (Array.isArray(managedFundsData) ? managedFundsData : managedFundsData?.data ?? []).map(normalizeManagedFund);
 
   const loansRaw = Array.isArray(loansData) ? loansData : loansData?.data ?? [];
   const approvedLoanAmount = loansRaw
@@ -220,7 +236,7 @@ function OrderModal({ security, activeTab, isEmployee, isSupervisor, onClose }) 
     }
 
     if (isSupervisor && buyForFund) {
-      const availableLiquidity = Number(selectedFund?.available_liquidity_rsd ?? selectedFund?.liquidity_rsd ?? 0);
+      const availableLiquidity = Number(selectedFund?.liquid_assets ?? selectedFund?.liquidity_rsd ?? 0);
       if (availableLiquidity > 0 && estimatedTotal > availableLiquidity) {
         setError(
           `Fond nema dovoljno raspoložive likvidnosti. Dostupno: ${availableLiquidity.toLocaleString('sr-RS', { minimumFractionDigits: 2 })}`
@@ -273,7 +289,16 @@ function OrderModal({ security, activeTab, isEmployee, isSupervisor, onClose }) 
 
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={e => e.stopPropagation()} style={{ maxWidth: 460 }}>
+      <div
+        className={styles.modal}
+        onClick={e => e.stopPropagation()}
+        style={{
+          maxWidth: 460,
+          maxHeight: 'calc(100vh - 32px)',
+          overflowY: 'auto',
+          width: '100%',
+        }}
+      >
         <div className={styles.modalHeader}>
           <h3>{isEmployee ? 'Kreiraj nalog' : 'Kupi'} — {security.ticker}</h3>
           <button className={styles.modalClose} onClick={onClose}>✕</button>
@@ -565,7 +590,7 @@ function OrderModal({ security, activeTab, isEmployee, isSupervisor, onClose }) 
 
                       {managedFunds.map((fund) => (
                         <option key={fund.fund_id} value={fund.fund_id}>
-                          {fund.fund_name}
+                          {fund.name}
                         </option>
                       ))}
                     </select>
@@ -573,7 +598,7 @@ function OrderModal({ security, activeTab, isEmployee, isSupervisor, onClose }) 
                     {selectedFund && (
                       <p style={{ fontSize: 12, color: 'var(--tx-3)', margin: '4px 0 0' }}>
                         Dostupna likvidnost fonda: {Number(
-                          selectedFund.available_liquidity_rsd ?? selectedFund.liquidity_rsd ?? 0
+                          selectedFund.liquid_assets ?? selectedFund.liquidity_rsd ?? 0
                         ).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}
                       </p>
                     )}

--- a/src/pages/funds/FundDetailsPage.jsx
+++ b/src/pages/funds/FundDetailsPage.jsx
@@ -1,4 +1,3 @@
-// src/pages/client/FundDetailsPage/FundDetailsPage.jsx
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import gsap from 'gsap';
@@ -11,6 +10,9 @@ import { useAuthStore } from '../../store/authStore';
 import ClientHeader from '../../components/layout/ClientHeader';
 import Navbar from '../../components/layout/Navbar';
 import Alert from '../../components/ui/Alert';
+
+import FundDepositModal from '../../features/portfolio/FundDepositModal';
+import FundWithdrawModal from '../../features/portfolio/FundWithdrawModal';
 
 import styles from './FundDetailsPage.module.css';
 import { getErrorMessage } from '../../utils/apiError';
@@ -29,6 +31,7 @@ export default function FundDetailsPage() {
     Boolean(perms?.can?.('investment.fund.manage'));
 
   const isClient = user?.identity_type === 'client';
+  const actuaryId = user?.employee_id ?? user?.id;
 
   const [fund, setFund] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -36,10 +39,9 @@ export default function FundDetailsPage() {
 
   const [feedback, setFeedback] = useState(null);
 
-    // Na vrh komponente, gde su ostali state-ovi
   const [modalType, setModalType] = useState('invest');
 
-  // invest modal
+  // client modal
   const [investOpen, setInvestOpen] = useState(false);
   const [investAmount, setInvestAmount] = useState('');
   const [investAccountNumber, setInvestAccountNumber] = useState('');
@@ -48,99 +50,93 @@ export default function FundDetailsPage() {
   const [accounts, setAccounts] = useState([]);
   const [accountsLoading, setAccountsLoading] = useState(false);
 
+  // supervisor modals
+  const [depositModal, setDepositModal] = useState(null);
+  const [withdrawModal, setWithdrawModal] = useState(null);
+
+  const fundId = fund?.id ?? fund?.fund_id ?? id;
+
+  async function reloadFundDetails() {
+    try {
+      setLoading(true);
+      setError('');
+      const payload = await investmentFundsApi.getFundDetails(id);
+      setFund(payload);
+    } catch (e) {
+      console.error(e);
+      setError(getErrorMessage(e, 'Greška pri učitavanju fonda.'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
   const handleSellHoldings = async (asset) => {
-  const assetId = asset.id ?? asset.asset_id ?? asset.assetId;
-  
+    const assetId = asset.id ?? asset.asset_id ?? asset.assetId;
 
-  if (!assetId) {
-    setFeedback({ type: 'greska', text: 'Interna greška: ID hartije nije pronađen.' });
-    return;
-  }
+    if (!assetId) {
+      setFeedback({ type: 'greska', text: 'Interna greška: ID hartije nije pronađen.' });
+      return;
+    }
 
-  if (!window.confirm(`Da li ste sigurni da želite da prodate hartiju ${asset.ticker}?`)) return;
-  
-  try {
-    setLoading(true);
-    // Payload zavisi od bekenda, obično traže količinu (volume)
-    await investmentFundsApi.sellFundAsset(fundId, assetId, {
-      volume: asset.volume,
-      ticker: asset.ticker
-    });
+    if (!window.confirm(`Da li ste sigurni da želite da prodate hartiju ${asset.ticker}?`)) return;
 
-    setFeedback({ type: 'uspeh', text: `Uspešno prodata hartija ${asset.ticker}.` });
-    
-    // Osvežavanje podataka nakon prodaje
-    const updatedFund = await investmentFundsApi.getFundDetails(id);
-    setFund(updatedFund);
-  } catch (err) {
-    setFeedback({ type: 'greska', text: getErrorMessage(err, 'Greška pri prodaji hartije.') });
-  } finally {
-    setLoading(false);
-  }
-};
+    try {
+      setLoading(true);
+      await investmentFundsApi.sellFundAsset(fundId, assetId, {
+        volume: asset.volume,
+        ticker: asset.ticker,
+      });
 
-// Za klijenta: Povlačenje sopstvenih sredstava
-const handleClientWithdraw = async (e) => {
-  if (e) e.preventDefault(); // Sprečava reload ako je unutar forme
+      setFeedback({ type: 'uspeh', text: `Uspešno prodata hartija ${asset.ticker}.` });
+      await reloadFundDetails();
+    } catch (err) {
+      setFeedback({ type: 'greska', text: getErrorMessage(err, 'Greška pri prodaji hartije.') });
+    } finally {
+      setLoading(false);
+    }
+  };
 
-  const amount = Number(investAmount);
+  const handleClientWithdraw = async (e) => {
+    if (e) e.preventDefault();
 
-  // Provera kao i za investiranje
-  if (!investAmount || isNaN(amount) || amount <= 0) {
-    setFeedback({ type: 'greska', text: 'Unesite validan iznos.' });
-    return;
-  }
+    const amount = Number(investAmount);
 
-  if (!investAccountNumber) {
-    setFeedback({ type: 'greska', text: 'Izaberite račun.' });
-    return;
-  }
+    if (!investAmount || Number.isNaN(amount) || amount <= 0) {
+      setFeedback({ type: 'greska', text: 'Unesite validan iznos.' });
+      return;
+    }
 
-  try {
-    setInvestSubmitting(true);
-    setFeedback(null);
+    if (!investAccountNumber) {
+      setFeedback({ type: 'greska', text: 'Izaberite račun.' });
+      return;
+    }
 
-    // Šaljemo payload koji pokriva i 'accountNumber' i 'AccountNumber'
-    const payload = {
-      amount: amount,
-      accountNumber: String(investAccountNumber),
-      AccountNumber: String(investAccountNumber) // Rešava tvoj "required" error
-    };
+    try {
+      setInvestSubmitting(true);
+      setFeedback(null);
 
-    await investmentFundsApi.withdrawFromFund(fundId, payload);
-    
-    setFeedback({ type: 'uspeh', text: 'Uspešno poslat zahtev za povlačenje.' });
-    setInvestOpen(false); // Zatvori modal
-    setInvestAmount('');  // Resetuj polje
-  } catch (err) {
-    setFeedback({ type: 'greska', text: getErrorMessage(err, 'Greška pri povlačenju.') });
-  } finally {
-    setInvestSubmitting(false);
-  }
-};
+      const payload = {
+        amount,
+        accountNumber: String(investAccountNumber),
+        AccountNumber: String(investAccountNumber),
+      };
 
-// Za supervizora: Direktna uplata/povlačenje na račun fonda
-const handleSupervisorFundAction = async (type) => {
-  const action = type === 'deposit' ? 'uplatu' : 'povlačenje';
-  const apiCall = type === 'deposit' 
-    ? investmentFundsApi.depositToFund 
-    : investmentFundsApi.withdrawFromFund;
+      await investmentFundsApi.withdrawFromFund(fundId, payload);
 
-  try {
-    setInvestSubmitting(true);
-    await apiCall(fundId, { amount: investAmount });
-    setFeedback({ type: 'uspeh', text: `Uspešno ste izvršili ${action}.` });
-  } catch (err) {
-    setFeedback({ type: 'greska', text: getErrorMessage(err, `Greška pri operaciji: ${action}.`) });
-  } finally {
-    setInvestSubmitting(false);
-  }
-};
+      setFeedback({ type: 'uspeh', text: 'Uspešno poslat zahtev za povlačenje.' });
+      setInvestOpen(false);
+      setInvestAmount('');
+      await reloadFundDetails();
+    } catch (err) {
+      setFeedback({ type: 'greska', text: getErrorMessage(err, 'Greška pri povlačenju.') });
+    } finally {
+      setInvestSubmitting(false);
+    }
+  };
 
   const HeaderComponent = isClient ? ClientHeader : Navbar;
   const headerProps = isClient ? { activeNav: 'funds' } : {};
 
-  // Load fund details (Swagger: GET /api/investment-funds/{fundId})
   useEffect(() => {
     let alive = true;
 
@@ -152,7 +148,7 @@ const handleSupervisorFundAction = async (type) => {
         const payload = await investmentFundsApi.getFundDetails(id);
         if (!alive) return;
 
-        setFund(payload); // interceptor should return object directly
+        setFund(payload);
       } catch (e) {
         console.error(e);
         if (!alive) return;
@@ -163,12 +159,12 @@ const handleSupervisorFundAction = async (type) => {
     }
 
     if (id) loadFund();
+
     return () => {
       alive = false;
     };
   }, [id]);
 
-  // Load client accounts for invest
   useEffect(() => {
     if (!isClient) return;
 
@@ -202,7 +198,9 @@ const handleSupervisorFundAction = async (type) => {
     };
 
     loadAccounts();
-    return () => { alive = false; };
+    return () => {
+      alive = false;
+    };
   }, [isClient, user]);
 
   useLayoutEffect(() => {
@@ -210,54 +208,69 @@ const handleSupervisorFundAction = async (type) => {
     const ctx = gsap.context(() => {
       const nodes = pageRef.current?.querySelectorAll('.page-anim') ?? [];
       if (!nodes.length) return;
-      gsap.from(nodes, { opacity: 0, y: 20, duration: 0.45, stagger: 0.08, ease: 'power2.out' });
+      gsap.from(nodes, {
+        opacity: 0,
+        y: 20,
+        duration: 0.45,
+        stagger: 0.08,
+        ease: 'power2.out',
+      });
     }, pageRef);
     return () => ctx.revert();
   }, [loading, fund]);
 
-  const holdings = useMemo(() => Array.isArray(fund?.holdings) ? fund.holdings : [], [fund]);
-  const performance = useMemo(() => Array.isArray(fund?.performance_history) ? fund.performance_history : [], [fund]);
+  const holdings = useMemo(
+    () => (Array.isArray(fund?.holdings) ? fund.holdings : []),
+    [fund]
+  );
 
-  const fundId = fund?.id ?? id;
+  const performance = useMemo(
+    () => (Array.isArray(fund?.performance_history) ? fund.performance_history : []),
+    [fund]
+  );
 
   async function handleInvestSubmit(e) {
-  e.preventDefault();
-  const amount = Number(investAmount);
+    e.preventDefault();
+    const amount = Number(investAmount);
 
-  if (!investAccountNumber) {
-    setFeedback({ type: 'greska', text: 'Izaberite račun.' });
-    return;
-  }
-
-  try {
-    setInvestSubmitting(true);
-    setFeedback(null);
-
-    // Payload koji rešava "AccountNumber" error
-    const payload = {
-      amount,
-      accountNumber: String(investAccountNumber),
-      AccountNumber: String(investAccountNumber), // Obavezno za backend
-      account_number: String(investAccountNumber),
-    };
-
-    if (modalType === 'invest') {
-      await investmentFundsApi.investInFund(fundId, payload);
-      setFeedback({ type: 'uspeh', text: 'Investicija uspešna!' });
-    } else {
-      // OVO JE DEO KOJI TI JE FALIO:
-      await investmentFundsApi.withdrawFromFund(fundId, payload);
-      setFeedback({ type: 'uspeh', text: 'Zahtev za povlačenje poslat!' });
+    if (Number.isNaN(amount) || amount <= 0) {
+      setFeedback({ type: 'greska', text: 'Unesite validan iznos.' });
+      return;
     }
 
-    setInvestOpen(false);
-    setInvestAmount('');
-  } catch (err) {
-    setFeedback({ type: 'greska', text: getErrorMessage(err, 'Akcija nije uspela.') });
-  } finally {
-    setInvestSubmitting(false);
+    if (!investAccountNumber) {
+      setFeedback({ type: 'greska', text: 'Izaberite račun.' });
+      return;
+    }
+
+    try {
+      setInvestSubmitting(true);
+      setFeedback(null);
+
+      const payload = {
+        amount,
+        accountNumber: String(investAccountNumber),
+        AccountNumber: String(investAccountNumber),
+        account_number: String(investAccountNumber),
+      };
+
+      if (modalType === 'invest') {
+        await investmentFundsApi.investInFund(fundId, payload);
+        setFeedback({ type: 'uspeh', text: 'Investicija uspešna!' });
+      } else {
+        await investmentFundsApi.withdrawFromFund(fundId, payload);
+        setFeedback({ type: 'uspeh', text: 'Zahtev za povlačenje poslat!' });
+      }
+
+      setInvestOpen(false);
+      setInvestAmount('');
+      await reloadFundDetails();
+    } catch (err) {
+      setFeedback({ type: 'greska', text: getErrorMessage(err, 'Akcija nije uspela.') });
+    } finally {
+      setInvestSubmitting(false);
+    }
   }
-}
 
   if (loading) {
     return (
@@ -319,7 +332,6 @@ const handleSupervisorFundAction = async (type) => {
           <InfoCard label="Profit" value={formatRSD(fund.profit)} />
         </section>
 
-        {/* Holdings table */}
         <section className={`page-anim ${styles.card}`}>
           <div className={styles.cardHeader}>
             <div>
@@ -357,16 +369,16 @@ const handleSupervisorFundAction = async (type) => {
                       <td>{formatNumber(h.volume)}</td>
                       <td>{formatRSD(h.initial_margin_cost)}</td>
                       <td>{formatDate(h.acquisition_date)}</td>
- {isSupervisor && (
-  <td>
-    <button
-      className={styles.btnSecondary} // Promeni stil da ne bude ghost ako je aktivno
-      onClick={() => handleSellHoldings(h)}
-    >
-      Prodaj
-    </button>
-  </td>
-)}
+                      {isSupervisor && (
+                        <td>
+                          <button
+                            className={styles.btnSecondary}
+                            onClick={() => handleSellHoldings(h)}
+                          >
+                            Prodaj
+                          </button>
+                        </td>
+                      )}
                     </tr>
                   ))
                 )}
@@ -375,7 +387,6 @@ const handleSupervisorFundAction = async (type) => {
           </div>
         </section>
 
-        {/* Performance */}
         <section className={`page-anim ${styles.card}`}>
           <div className={styles.cardHeader}>
             <div>
@@ -416,123 +427,153 @@ const handleSupervisorFundAction = async (type) => {
           </div>
         </section>
 
-{/* Actions */}
-<section className={`page-anim ${styles.actionSection}`}>
-  {isClient && (
-    <>
-      <button 
-        className={styles.btnPrimary} 
-        onClick={() => {
-          setModalType('invest'); // Kažeš: želim da investiram
-          setInvestOpen(true);
-        }}
-      >
-        Investiraj
-      </button>
+        <section className={`page-anim ${styles.actionSection}`}>
+          {isClient && (
+            <>
+              <button
+                className={styles.btnPrimary}
+                onClick={() => {
+                  setModalType('invest');
+                  setInvestOpen(true);
+                }}
+              >
+                Investiraj
+              </button>
 
-      <button 
-        className={styles.btnGhost} 
-        onClick={() => {
-          setModalType('withdraw'); // Kažeš: želim da povučem pare
-          setInvestOpen(true);
-        }}
-      >
-        Povuci sredstva
-      </button>
-    </>
-  )}
+              <button
+                className={styles.btnGhost}
+                onClick={() => {
+                  setModalType('withdraw');
+                  setInvestOpen(true);
+                }}
+              >
+                Povuci sredstva
+              </button>
+            </>
+          )}
 
-  {isSupervisor && (
-    <>
-      <button className={styles.btnPrimary} onClick={() => handleSupervisorFundAction('deposit')}>
-        Uplata u fond
-      </button>
-      <button className={styles.btnGhost} onClick={() => handleSupervisorFundAction('withdraw')}>
-        Povlačenje iz fonda
-      </button>
-    </>
-  )}
-</section>
+          {isSupervisor && (
+            <>
+              <button
+                className={styles.btnPrimary}
+                onClick={() => setDepositModal(fund)}
+              >
+                Uplata u fond
+              </button>
+
+              <button
+                className={styles.btnGhost}
+                onClick={() => setWithdrawModal(fund)}
+              >
+                Povlačenje iz fonda
+              </button>
+            </>
+          )}
+        </section>
       </main>
 
-{/* Invest modal */}
-{investOpen && (
-  <div className={styles.modalBackdrop} onClick={() => setInvestOpen(false)}>
-    <div className={styles.modalCard} onClick={(e) => e.stopPropagation()}>
-      <div className={styles.modalHeader}>
-        <div>
-          {/* DINAMIČKI NASLOV */}
-          <h3 className={styles.modalTitle}>
-            {modalType === 'invest' ? 'Investiraj u fond' : 'Povuci sredstva iz fonda'}
-          </h3>
-          <p className={styles.modalText}>
-            Fond: <strong>{fund.name}</strong>
-          </p>
-        </div>
-        <button className={styles.closeBtn} onClick={() => setInvestOpen(false)}>×</button>
-      </div>
+      {investOpen && (
+        <div className={styles.modalBackdrop} onClick={() => setInvestOpen(false)}>
+          <div className={styles.modalCard} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <div>
+                <h3 className={styles.modalTitle}>
+                  {modalType === 'invest' ? 'Investiraj u fond' : 'Povuci sredstva iz fonda'}
+                </h3>
+                <p className={styles.modalText}>
+                  Fond: <strong>{fund.name}</strong>
+                </p>
+              </div>
+              <button className={styles.closeBtn} onClick={() => setInvestOpen(false)}>×</button>
+            </div>
 
-      <form onSubmit={handleInvestSubmit} className={styles.modalBody}>
-        <div className={styles.field}>
-          <label>Račun *</label>
-          <select
-            value={investAccountNumber}
-            onChange={(e) => setInvestAccountNumber(e.target.value)}
-            required
-            disabled={accountsLoading || accounts.length === 0}
-          >
-            {accountsLoading ? (
-              <option value="">Učitavanje računa...</option>
-            ) : accounts.length === 0 ? (
-              <option value="">Nema dostupnih računa</option>
-            ) : (
-              accounts.map((acc) => (
-                <option key={acc.account_number} value={acc.account_number}>
-                  {acc.name ?? 'Račun'} — {acc.account_number}
-                </option>
-              ))
-            )}
-          </select>
-        </div>
+            <form onSubmit={handleInvestSubmit} className={styles.modalBody}>
+              <div className={styles.field}>
+                <label>Račun *</label>
+                <select
+                  value={investAccountNumber}
+                  onChange={(e) => setInvestAccountNumber(e.target.value)}
+                  required
+                  disabled={accountsLoading || accounts.length === 0}
+                >
+                  {accountsLoading ? (
+                    <option value="">Učitavanje računa...</option>
+                  ) : accounts.length === 0 ? (
+                    <option value="">Nema dostupnih računa</option>
+                  ) : (
+                    accounts.map((acc) => (
+                      <option key={acc.account_number} value={acc.account_number}>
+                        {acc.name ?? 'Račun'} — {acc.account_number}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
 
-        <div className={styles.field}>
-          <label>Iznos (RSD) *</label>
-          <input
-            type="number"
-            min="0.01"
-            step="0.01"
-            placeholder="Unesite iznos..."
-            value={investAmount}
-            onChange={(e) => setInvestAmount(e.target.value)}
-            required
-          />
-        </div>
+              <div className={styles.field}>
+                <label>Iznos (RSD) *</label>
+                <input
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  placeholder="Unesite iznos..."
+                  value={investAmount}
+                  onChange={(e) => setInvestAmount(e.target.value)}
+                  required
+                />
+              </div>
 
-        <div className={styles.formActions}>
-          <button 
-            type="button" 
-            className={styles.btnGhost} 
-            onClick={() => setInvestOpen(false)} 
-            disabled={investSubmitting}
-          >
-            Otkaži
-          </button>
-          <button 
-            type="submit" 
-            className={styles.btnPrimary} 
-            disabled={investSubmitting}
-          >
-            {/* DINAMIČKI TEKST NA DUGMETU */}
-            {investSubmitting 
-              ? 'Slanje...' 
-              : (modalType === 'invest' ? 'Potvrdi investiciju' : 'Potvrdi povlačenje')
-            }
-          </button>
+              <div className={styles.formActions}>
+                <button
+                  type="button"
+                  className={styles.btnGhost}
+                  onClick={() => setInvestOpen(false)}
+                  disabled={investSubmitting}
+                >
+                  Otkaži
+                </button>
+                <button
+                  type="submit"
+                  className={styles.btnPrimary}
+                  disabled={investSubmitting}
+                >
+                  {investSubmitting
+                    ? 'Slanje...'
+                    : (modalType === 'invest' ? 'Potvrdi investiciju' : 'Potvrdi povlačenje')}
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
-      </form>
-    </div>
-  </div>
-)}
+      )}
+
+      {depositModal && (
+        <FundDepositModal
+          fund={depositModal}
+          actuaryId={actuaryId}
+          isSupervisor={true}
+          onClose={() => setDepositModal(null)}
+          onSuccess={() => {
+            setDepositModal(null);
+            setFeedback({ type: 'uspeh', text: 'Uspešno ste izvršili uplatu u fond.' });
+            reloadFundDetails();
+          }}
+        />
+      )}
+
+      {withdrawModal && (
+        <FundWithdrawModal
+          fund={withdrawModal}
+          actuaryId={actuaryId}
+          isSupervisor={true}
+          onClose={() => setWithdrawModal(null)}
+          onSuccess={() => {
+            setWithdrawModal(null);
+            setFeedback({ type: 'uspeh', text: 'Uspešno ste izvršili povlačenje iz fonda.' });
+            reloadFundDetails();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -550,7 +591,10 @@ function formatRSD(value) {
   if (value == null || value === '—') return '—';
   const num = Number(value);
   if (Number.isNaN(num)) return '—';
-  return `${new Intl.NumberFormat('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(num)} RSD`;
+  return `${new Intl.NumberFormat('sr-RS', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(num)} RSD`;
 }
 
 function formatNumber(value) {


### PR DESCRIPTION
E2E testovi za funds/order flow + ispravke funds mapping-a i modal flow-a

- Dodati Cypress testovi za scenarije 36, 37, 38, 39, 40, 41, 42, 44, 45
- Testovi su prilagođeni da rade sa stvarnim podacima i stvarnim endpointima, bez mock-ova

Promene u kodu

- Ispravljen mapping za client/supervisor funds response jer UI nije pravilno čitao backend shape, pa su se prikazivale 0/— vrednosti ili prazne liste
- Ispravljen PortfolioPage / funds tab flow da koristi odgovarajući funds prikaz u zavisnosti od tipa korisnika
- Ispravljen SupervisorFundsTab da pravilno raspakuje response i normalizuje polja (fund_id/id, name/fund_name, description/fund_description, liquid_assets, fund_value)
- FundDetailsPage za supervizora prebačen da koristi postojeće FundDepositModal i FundWithdrawModal, umesto direktnog submit flow-a bez unosa iznosa
- Ispravljen fund modal flow da koristi tačan fund id/name iz objekta koji dobija sa details/discovery strane

Bugovi koji su rešeni

- pogrešan funds response mapping
- prazan “Moji fondovi” prikaz iako backend vraća podatke
- details strana za supervizora nije koristila ispravan modal flow

Bugovi koji jos postoje za back

- client share value za fond vraca pogresnu vrednost, npr korisnik je investirao 10000rsd a pise da ima preko 8 milijardi dobiti koje moze da withdrawuje, ali i dalje ima samo tih 10000
- nije bug, ali nema endpoint za brisanje fonda, pa u testu gde moram da napravim test-fond, taj fond samo ostane u listi fondova. moze rucno da se skloni iz baze pred odbranu, ili da se doda endpoint pa da brisem na kraju testa 
