### PR TITLE
fix: profit-bank cypress tests - fix intercepts and mock data

### DIFF
--- a/cypress/e2e/profit-bank/helpers.ts
+++ b/cypress/e2e/profit-bank/helpers.ts
@@ -1,0 +1,54 @@
+import { supervisorUser, agentUser, loginAs } from '../../support/helpers';
+
+export { supervisorUser, agentUser, loginAs };
+
+export function tradingApiUrl(): string {
+  const url = Cypress.env('TRADING_API_URL') as string | undefined;
+  return url && !url.includes('localhost') ? url : 'http://rafsi.davidovic.io:8082/api';
+}
+
+export function bankingApiUrl(): string {
+  const url = Cypress.env('BANKING_API_URL') as string | undefined;
+  return url && !url.includes('localhost') ? url : 'http://rafsi.davidovic.io:8081/api';
+}
+
+export const mockActuaries = [
+  {
+    actuary_id: 101,
+    first_name: 'Milan',
+    last_name: 'Marković',
+    position: 'AGENT',
+    profit_rsd: 150000.5,
+  },
+  {
+    actuary_id: 102,
+    first_name: 'Sara',
+    last_name: 'Supervizor',
+    position: 'SUPERVISOR',
+    profit_rsd: 320000.0,
+  },
+];
+
+export const mockFunds = [
+  {
+    fund_id: 1,
+    fund_name: 'Alpha Fond',
+    manager_name: 'Sara Supervizor',
+    bank_share_pct: 25.0,
+    bank_share_value: 500000,
+    profit: 30000,
+    liquidity_rsd: 200000,
+    liquid_assets: 200000,
+  },
+];
+
+export const mockBankAccounts = [
+  {
+    account_number: '340-111-222-33',
+    name: 'Tekući račun banke',
+    account_type: 'bank',
+    company_id: 1,
+    balance: 1000000,
+    currency: 'RSD',
+  },
+];

--- a/cypress/e2e/profit-bank/scenario-47-supervisor-sees-actuaries-profit.cy.ts
+++ b/cypress/e2e/profit-bank/scenario-47-supervisor-sees-actuaries-profit.cy.ts
@@ -1,0 +1,57 @@
+import { loginAs, mockActuaries, supervisorUser, tradingApiUrl, bankingApiUrl } from './helpers';
+
+describe('Scenario 47: Supervizor vidi spisak aktuara sa profitom', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `${tradingApiUrl()}/profit/actuaries`, {
+      statusCode: 200,
+      body: mockActuaries,
+    }).as('getActuaryPerformances');
+
+    cy.intercept('GET', `${tradingApiUrl()}/profit/funds`, {
+      statusCode: 200,
+      body: [],
+    }).as('getFundPositions');
+
+    cy.intercept('GET', `${bankingApiUrl()}/accounts**`, {
+      statusCode: 200,
+      body: { data: [] },
+    }).as('getAccounts');
+
+    cy.intercept('GET', '**/actuary/**/assets**', {
+      statusCode: 200,
+      body: [],
+    }).as('getActuaryPortfolio');
+
+    cy.intercept('GET', `${tradingApiUrl()}/investment-funds**`, {
+      statusCode: 200,
+      body: { data: [], total: 0 },
+    }).as('getFunds');
+
+    cy.intercept('POST', '**/auth/refresh**', {
+      statusCode: 200,
+      body: { token: 'test-token', refresh_token: 'test-refresh-token' },
+    }).as('tokenRefresh');
+
+    loginAs(supervisorUser, '/profit-bank');
+  });
+
+  it('vidi listu svih aktuara sa imenom, prezimenom i profitom u RSD', () => {
+    cy.wait('@getActuaryPerformances');
+
+    cy.contains('button', 'Profit aktuara').should('be.visible');
+
+    cy.get('table thead th').should('contain', 'Ime');
+    cy.get('table thead th').should('contain', 'Prezime');
+    cy.get('table thead th').should('contain', 'Profit u RSD');
+
+    cy.get('table tbody tr').should('have.length.greaterThan', 0);
+
+    cy.contains('td', 'Milan').should('be.visible');
+    cy.contains('td', 'Marković').should('be.visible');
+
+    cy.contains('td', 'Sara').should('be.visible');
+    cy.contains('td', 'Supervizor').should('be.visible');
+
+    cy.contains('td', /RSD/).should('be.visible');
+  });
+});

--- a/cypress/e2e/profit-bank/scenario-48-agent-denied-profit-bank.cy.ts
+++ b/cypress/e2e/profit-bank/scenario-48-agent-denied-profit-bank.cy.ts
@@ -1,0 +1,12 @@
+import { agentUser, loginAs } from './helpers';
+
+describe('Scenario 48: Agent nema pristup portalu Profit Banke', () => {
+  it('dobija odbijen pristup i biva preusmerena na dashboard', () => {
+    loginAs(agentUser, '/profit-bank');
+
+    cy.location('pathname', { timeout: 10000 }).should('not.eq', '/profit-bank');
+
+    cy.contains('Profit Banke').should('not.exist');
+    cy.contains('Portal dostupan isključivo supervizorima').should('not.exist');
+  });
+});

--- a/cypress/e2e/profit-bank/scenario-49-supervisor-deposits-to-fund.cy.ts
+++ b/cypress/e2e/profit-bank/scenario-49-supervisor-deposits-to-fund.cy.ts
@@ -1,0 +1,67 @@
+import { loginAs, mockBankAccounts, mockFunds, supervisorUser, tradingApiUrl, bankingApiUrl } from './helpers';
+
+describe('Scenario 49: Supervizor uplaćuje novac u fond u ime banke', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `${tradingApiUrl()}/profit/actuaries`, {
+      statusCode: 200,
+      body: [],
+    }).as('getActuaryPerformances');
+
+    cy.intercept('GET', `${tradingApiUrl()}/profit/funds`, {
+      statusCode: 200,
+      body: mockFunds,
+    }).as('getFundPositions');
+
+    cy.intercept('GET', `${bankingApiUrl()}/accounts**`, {
+      statusCode: 200,
+      body: mockBankAccounts,
+    }).as('getAccounts');
+
+    cy.intercept('GET', '**/actuary/**/assets**', {
+      statusCode: 200,
+      body: [],
+    }).as('getActuaryPortfolio');
+
+    cy.intercept('GET', `${tradingApiUrl()}/investment-funds**`, {
+      statusCode: 200,
+      body: { data: [], total: 0 },
+    }).as('getFunds');
+
+    cy.intercept('POST', '**/auth/refresh**', {
+      statusCode: 200,
+      body: { token: 'test-token', refresh_token: 'test-refresh-token' },
+    }).as('tokenRefresh');
+
+    cy.intercept('POST', `${tradingApiUrl()}/investment-funds/*/invest`, (req) => {
+      expect(req.body).to.not.have.property('commission');
+      req.reply({ statusCode: 200, body: { message: 'Uplata uspešna.' } });
+    }).as('depositToFund');
+
+    loginAs(supervisorUser, '/profit-bank');
+  });
+
+  it('prebacuje novac sa bankovnog računa na račun fonda bez provizije', () => {
+    cy.contains('button', 'Pozicije u fondovima').click();
+
+    cy.wait('@getFundPositions');
+
+    cy.contains('td', 'Alpha Fond').should('be.visible');
+
+    cy.contains('tr', 'Alpha Fond').within(() => {
+      cy.contains('button', 'Uplata u fond').click();
+    });
+
+    cy.get('select').select('340-111-222-33');
+
+    cy.get('input[type="number"]').clear().type('50000');
+
+    cy.contains('button', 'Potvrdi').click();
+
+    cy.wait('@depositToFund').then(({ request }) => {
+      expect(request.body).to.not.have.property('commission');
+      expect(request.body.amount).to.eq(50000);
+    });
+
+    cy.contains('Uplata u fond je uspešno evidentirana').should('be.visible');
+  });
+});

--- a/cypress/e2e/profit-bank/scenario-50-supervisor-withdraws-from-fund.cy.ts
+++ b/cypress/e2e/profit-bank/scenario-50-supervisor-withdraws-from-fund.cy.ts
@@ -1,0 +1,69 @@
+import { loginAs, mockBankAccounts, mockFunds, supervisorUser, tradingApiUrl, bankingApiUrl } from './helpers';
+
+describe('Scenario 50: Supervizor povlači novac iz fonda za banku - bez provizije', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `${tradingApiUrl()}/profit/actuaries`, {
+      statusCode: 200,
+      body: [],
+    }).as('getActuaryPerformances');
+
+    cy.intercept('GET', `${tradingApiUrl()}/profit/funds`, {
+      statusCode: 200,
+      body: mockFunds,
+    }).as('getFundPositions');
+
+    cy.intercept('GET', `${bankingApiUrl()}/accounts**`, {
+      statusCode: 200,
+      body: mockBankAccounts,
+    }).as('getAccounts');
+
+    cy.intercept('GET', '**/actuary/**/assets**', {
+      statusCode: 200,
+      body: [],
+    }).as('getActuaryPortfolio');
+
+    cy.intercept('GET', `${tradingApiUrl()}/investment-funds**`, {
+      statusCode: 200,
+      body: { data: [], total: 0 },
+    }).as('getFunds');
+
+    cy.intercept('POST', '**/auth/refresh**', {
+      statusCode: 200,
+      body: { token: 'test-token', refresh_token: 'test-refresh-token' },
+    }).as('tokenRefresh');
+
+    cy.intercept('POST', `${tradingApiUrl()}/investment-funds/*/withdraw`, (req) => {
+      expect(req.body).to.not.have.property('commission');
+      req.reply({ statusCode: 200, body: { message: 'Povlačenje uspešno.' } });
+    }).as('withdrawFromFund');
+
+    loginAs(supervisorUser, '/profit-bank');
+  });
+
+  it('prebacuje novac na bankovni račun bez provizije', () => {
+    cy.contains('button', 'Pozicije u fondovima').click();
+
+    cy.wait('@getFundPositions');
+
+    cy.contains('td', 'Alpha Fond').should('be.visible');
+
+    cy.contains('tr', 'Alpha Fond').within(() => {
+      cy.contains('button', 'Povlačenje iz fonda').click();
+    });
+
+    cy.contains('Dostupna likvidnost fonda').should('be.visible');
+
+    cy.get('select').select('340-111-222-33');
+
+    cy.get('input[type="number"]').clear().type('10000');
+
+    cy.contains('button', 'Potvrdi').click();
+
+    cy.wait('@withdrawFromFund').then(({ request }) => {
+      expect(request.body).to.not.have.property('commission');
+      expect(request.body.amount).to.eq(10000);
+    });
+
+    cy.contains('Povlačenje iz fonda je uspešno evidentirano').should('be.visible');
+  });
+});


### PR DESCRIPTION
- Replace overly broad **/accounts** glob with specific bankingApiUrl() pattern to prevent Cypress from intercepting Vite module files
- Add missing investment-funds and auth/refresh intercepts to prevent 401-triggered logout before page mounts
- Fix bankingApiUrl() fallback port 8080 -> 8081 to match VITE_BANKING_API_URL
- Fix mockBankAccounts account_type 'current' -> 'bank' + company_id: 1 so getBankAccounts() filter passes and select options render
- Remove catch-all GET **/* intercept in scenario-48 that blocked HTML load