### PR TITLE
 feat/otc-polling-dostupne-akcije

### DIFF
--- a/src/api/endpoints/otc.js
+++ b/src/api/endpoints/otc.js
@@ -1,7 +1,7 @@
 import { tradingApi as api } from '../client';
 
 export const otcApi = {
-  getPublicListings:   (params = {})          => api.get('/otc/public', { params }),
+  getPublicListings:   (params = {}, signal)   => api.get('/otc/public', { params, signal }),
   createOffer:         (payload)               => api.post('/otc/offers', payload),
   getContracts:        ()                      => api.get('/otc/contracts'),
   exerciseContract:    (contractId, data)      => api.post(`/otc/contracts/${contractId}/exercise`, data),

--- a/src/pages/otc/OtcPortalPage.jsx
+++ b/src/pages/otc/OtcPortalPage.jsx
@@ -94,35 +94,100 @@ function ConfirmModal({ contract, accounts, selectedAccount, onAccountChange, on
 
 // ─── Tab: Dostupne akcije (OTC Portal) ───────────────────────────────────────
 function DostupneAkcije() {
+  const POLL_INTERVAL = 30_000;
+
   const user = useAuthStore(s => s.user);
-  const [stocks, setStocks]       = useState([]);
-  const [accounts, setAccounts]   = useState([]);
-  const [loading, setLoading]     = useState(true);
-  const [error, setError]         = useState('');
+  const [stocks, setStocks]         = useState([]);
+  const [accounts, setAccounts]     = useState([]);
+  const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState('');
   const [offerStock, setOfferStock] = useState(null);
   const [successMsg, setSuccessMsg] = useState('');
 
+  const intervalRef   = useRef(null);
+  const abortRef      = useRef(null);
+  const offerStockRef = useRef(null);
+
+  // Keep ref in sync so the polling callback reads the latest value without a stale closure
+  useEffect(() => { offerStockRef.current = offerStock; }, [offerStock]);
+
+  async function fetchListings(signal) {
+    try {
+      const res = await otcApi.getPublicListings({}, signal);
+      if (signal?.aborted) return;
+      const list = Array.isArray(res) ? res : (res?.data ?? res?.content ?? []);
+      setStocks(list);
+    } catch (err) {
+      if (err?.name === 'AbortError' || err?.code === 'ERR_CANCELED' || err?.name === 'CanceledError') return;
+      throw err;
+    }
+  }
+
   useEffect(() => {
-    async function load() {
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
+    function stopPolling() {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    function startPolling() {
+      if (intervalRef.current) return;
+      intervalRef.current = setInterval(() => {
+        if (document.visibilityState !== 'visible') return;
+        if (offerStockRef.current !== null) return;
+        abortRef.current?.abort();
+        const pollCtrl = new AbortController();
+        abortRef.current = pollCtrl;
+        fetchListings(pollCtrl.signal).catch(() => {});
+      }, POLL_INTERVAL);
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        if (offerStockRef.current === null) {
+          abortRef.current?.abort();
+          const visCtrl = new AbortController();
+          abortRef.current = visCtrl;
+          fetchListings(visCtrl.signal).catch(() => {});
+        }
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    }
+
+    async function initialLoad() {
+      const clientId = user?.client_id ?? user?.id;
       try {
         setLoading(true);
         setError('');
-        const clientId = user?.client_id ?? user?.id;
-        const [res, accsRes] = await Promise.all([
-          otcApi.getPublicListings(),
-          clientId ? accountsApi.getClientAccounts(clientId).catch(() => []) : Promise.resolve([]),
-        ]);
-        const list = Array.isArray(res) ? res : (res?.data ?? res?.content ?? []);
+        const accsPromise = clientId
+          ? accountsApi.getClientAccounts(clientId).catch(() => [])
+          : Promise.resolve([]);
+        const [, accsRes] = await Promise.all([fetchListings(ctrl.signal), accsPromise]);
+        if (ctrl.signal.aborted) return;
         const accs = Array.isArray(accsRes) ? accsRes : (accsRes?.data ?? []);
-        setStocks(list);
         setAccounts(accs);
-      } catch {
+      } catch (err) {
+        if (err?.name === 'AbortError' || err?.code === 'ERR_CANCELED' || err?.name === 'CanceledError') return;
         setError('Nije moguće učitati dostupne akcije.');
       } finally {
-        setLoading(false);
+        if (!ctrl.signal.aborted) setLoading(false);
       }
     }
-    load();
+
+    initialLoad().then(() => {
+      if (document.visibilityState === 'visible') startPolling();
+    });
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      stopPolling();
+      abortRef.current?.abort();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, []);
 
   async function handleOfferSubmit(payload) {


### PR DESCRIPTION
## Summary

Adds 30-second polling to the `DostupneAkcije` component as required by spec ("refresh može da se vrši na nekom vremenskom intervalu").

Closes #149

## Changes

**`src/api/endpoints/otc.js`**
- Added optional `signal` parameter to `getPublicListings` — fully backward-compatible

**`src/pages/otc/OtcPortalPage.jsx`**
- `POLL_INTERVAL = 30_000` constant at top of component
- `fetchListings(signal)` extracted as reusable function
- `setInterval` polling every 30s after initial load
- `AbortController` cancels in-flight requests before each new poll (no race conditions)
- Visibility API: polling pauses when tab is hidden, resumes + triggers immediate refresh when tab becomes visible
- Modal guard: skips background refresh while `OfferModal` is open
- Full cleanup on unmount: clears interval, aborts request, removes event listener
- Background refreshes do NOT reset the loading spinner — only initial mount shows the spinner

## Testing

No test data available in dev environment. Verified via:
- DevTools → Network → filter `/otc/public` → requests fire every ~30s ✓
- Vite build passes with no errors (`332 modules transformed`) ✓