### PR TITLE
Uveden Rollback za cypress testove koji menjaju bazu

### DIFF
--- a/cypress/e2e/funds/scenario-36-client-withdraw-insufficient-liquidity.cy.ts
+++ b/cypress/e2e/funds/scenario-36-client-withdraw-insufficient-liquidity.cy.ts
@@ -1,8 +1,34 @@
 import { extractFunds, extractAccounts } from '../../support/helpers';
 
+function getDirectApiUrl(targetPort: 8080 | 8081 | 8082) {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  return apiUrl
+    .replace(':8080/api', `:${targetPort}/api`)
+    .replace(':8081/api', `:${targetPort}/api`)
+    .replace(':8082/api', `:${targetPort}/api`);
+}
+
 describe('Scenario 36: Klijent povlači novac iz fonda - nedovoljna likvidnost', () => {
+  let clientToken: string | null = null;
+  let rollbackFundId: string | null = null;
+  let rollbackAmount: number | null = null;
+  let rollbackAccountNumber: string | null = null;
+  let shouldRollback = false;
+
   beforeEach(() => {
+    clientToken = null;
+    rollbackFundId = null;
+    rollbackAmount = null;
+    rollbackAccountNumber = null;
+    shouldRollback = false;
+
     cy.loginAsClientAna();
+
+    cy.window().then((win) => {
+      clientToken = win.localStorage.getItem('token');
+    });
 
     cy.intercept('GET', '**/api/client/*/assets*').as('getPortfolio');
     cy.intercept('GET', '**/api/client/*/funds*').as('getClientFunds');
@@ -10,6 +36,25 @@ describe('Scenario 36: Klijent povlači novac iz fonda - nedovoljna likvidnost',
     cy.intercept('POST', '**/api/investment-funds/*/withdraw').as('withdrawFromFund');
 
     cy.visit('/client/portfolio');
+  });
+
+  afterEach(() => {
+    if (!shouldRollback || !clientToken || !rollbackFundId || !rollbackAmount || !rollbackAccountNumber) {
+      return;
+    }
+
+    cy.request({
+      method: 'POST',
+      url: `${getDirectApiUrl(8082)}/investment-funds/${rollbackFundId}/invest`,
+      headers: {
+        Authorization: `Bearer ${clientToken}`,
+      },
+      body: {
+        account_number: rollbackAccountNumber,
+        amount: rollbackAmount,
+      },
+      failOnStatusCode: false,
+    });
   });
 
   it('šalje withdrawal zahtev za Anin fond', () => {
@@ -34,6 +79,10 @@ describe('Scenario 36: Klijent povlači novac iz fonda - nedovoljna likvidnost',
 
     cy.get('@targetFund').then((fund: any) => {
       const fundName = fund.fund_name ?? fund.name;
+      const fundId = String(fund.fund_id ?? fund.id);
+
+      rollbackFundId = fundId;
+      rollbackAmount = 2000;
 
       cy.contains(fundName).should('be.visible');
       cy.contains(fundName)
@@ -66,6 +115,8 @@ describe('Scenario 36: Klijent povlači novac iz fonda - nedovoljna likvidnost',
       const accountNumber =
         acc.account_number ?? acc.accountNumber ?? acc.AccountNumber ?? acc.number;
 
+      rollbackAccountNumber = String(accountNumber);
+
       cy.get('select').select(String(accountNumber));
     });
 
@@ -75,6 +126,10 @@ describe('Scenario 36: Klijent povlači novac iz fonda - nedovoljna likvidnost',
       expect([200, 201, 202, 400, 409, 422]).to.include(response?.statusCode);
       expect(Number(request.body.amount)).to.eq(2000);
       expect(request.body.account_number).to.exist;
+
+      if ([200, 201, 202].includes(response?.statusCode ?? 0)) {
+        shouldRollback = true;
+      }
     });
   });
 });

--- a/cypress/e2e/funds/scenario-37-client-pays-fee-on-foreign-currency-withdrawal.cy.ts
+++ b/cypress/e2e/funds/scenario-37-client-pays-fee-on-foreign-currency-withdrawal.cy.ts
@@ -1,8 +1,34 @@
 import { extractFunds, extractAccounts } from '../../support/helpers';
 
+function getDirectApiUrl(targetPort: 8080 | 8081 | 8082) {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  return apiUrl
+    .replace(':8080/api', `:${targetPort}/api`)
+    .replace(':8081/api', `:${targetPort}/api`)
+    .replace(':8082/api', `:${targetPort}/api`);
+}
+
 describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti', () => {
+  let clientToken: string | null = null;
+  let rollbackFundId: string | null = null;
+  let rollbackAmount: number | null = null;
+  let rollbackAccountNumber: string | null = null;
+  let shouldRollback = false;
+
   beforeEach(() => {
+    clientToken = null;
+    rollbackFundId = null;
+    rollbackAmount = null;
+    rollbackAccountNumber = null;
+    shouldRollback = false;
+
     cy.loginAsClientAna();
+
+    cy.window().then((win) => {
+      clientToken = win.localStorage.getItem('token');
+    });
 
     cy.intercept('GET', '**/api/client/*/assets*').as('getPortfolio');
     cy.intercept('GET', '**/api/client/*/funds*').as('getClientFunds');
@@ -12,7 +38,26 @@ describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti
     cy.visit('/client/portfolio');
   });
 
-  it('omogućava povlačenje na EUR račun za Anin fond', () => {
+  afterEach(() => {
+    if (!shouldRollback || !clientToken || !rollbackFundId || !rollbackAmount || !rollbackAccountNumber) {
+      return;
+    }
+
+    cy.request({
+      method: 'POST',
+      url: `${getDirectApiUrl(8082)}/investment-funds/${rollbackFundId}/invest`,
+      headers: {
+        Authorization: `Bearer ${clientToken}`,
+      },
+      body: {
+        account_number: rollbackAccountNumber,
+        amount: rollbackAmount,
+      },
+      failOnStatusCode: false,
+    });
+  });
+
+  it('omogućava povlačenje na USD račun za Anin fond', () => {
     cy.wait('@getPortfolio');
 
     cy.get('main').within(() => {
@@ -34,6 +79,10 @@ describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti
 
     cy.get('@targetFund').then((fund: any) => {
       const fundName = fund.fund_name ?? fund.name;
+      const fundId = String(fund.fund_id ?? fund.id);
+
+      rollbackFundId = fundId;
+      rollbackAmount = 1000;
 
       cy.contains(fundName).should('be.visible');
       cy.contains(fundName)
@@ -47,16 +96,16 @@ describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti
       expect(response?.statusCode).to.eq(200);
 
       const accounts = extractAccounts(response?.body);
-      const eurAccount = accounts.find(
+      const usdAccount = accounts.find(
         (acc: any) => String(acc.currency ?? '').toUpperCase() === 'USD'
       );
 
       expect(
-        eurAccount,
+        usdAccount,
         'Ana mora da ima bar jedan USD račun za scenario 37.'
       ).to.exist;
 
-      cy.wrap(eurAccount).as('targetAccount');
+      cy.wrap(usdAccount).as('targetAccount');
     });
 
     cy.get('input[value="partial"]').check({ force: true });
@@ -65,6 +114,8 @@ describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti
     cy.get('@targetAccount').then((acc: any) => {
       const accountNumber =
         acc.account_number ?? acc.accountNumber ?? acc.AccountNumber ?? acc.number;
+
+      rollbackAccountNumber = String(accountNumber);
 
       cy.get('select').select(String(accountNumber));
       cy.get('select').find('option:selected').should('contain.text', 'USD');
@@ -76,6 +127,10 @@ describe('Scenario 37: Klijent plaća proviziju pri povlačenju u stranoj valuti
       expect([200, 201, 202, 400, 409, 422]).to.include(response?.statusCode);
       expect(Number(request.body.amount)).to.eq(1000);
       expect(request.body.account_number).to.exist;
+
+      if ([200, 201, 202].includes(response?.statusCode ?? 0)) {
+        shouldRollback = true;
+      }
     });
   });
 });

--- a/cypress/e2e/funds/scenario-45-client-fund-percentage-changes-after-another-client-invests.cy.ts
+++ b/cypress/e2e/funds/scenario-45-client-fund-percentage-changes-after-another-client-invests.cy.ts
@@ -11,15 +11,14 @@ function pickArray(body: any) {
 }
 
 function loginOnly(email: string, password: string) {
-  return cy.request('POST', `${AUTH_API}/auth/login`, { email, password }).then((res) => {
-    expect(res.status).to.eq(200);
-    return res.body;
-  });
+  return cy.request('POST', `${AUTH_API}/auth/login`, { email, password });
 }
 
 function loginAndVisit(email: string, password: string, path: string) {
-  return loginOnly(email, password).then((body) => {
-    const { user, token, refresh_token } = body;
+  return loginOnly(email, password).then((res) => {
+    expect(res.status).to.eq(200);
+
+    const { user, token, refresh_token } = res.body;
 
     cy.visit(path, {
       onBeforeLoad(win) {
@@ -30,7 +29,7 @@ function loginAndVisit(email: string, password: string, path: string) {
       },
     });
 
-    return cy.wrap(body);
+    return cy.wrap(res.body);
   });
 }
 
@@ -44,14 +43,6 @@ function getFundId(fund: any) {
 
 function getFundName(fund: any) {
   return fund?.fund_name ?? fund?.name ?? '';
-}
-
-function getFundPercent(fund: any) {
-  return Number(
-    fund?.clients_share_percent ??
-    fund?.client_share_percentage ??
-    0
-  );
 }
 
 function fetchClientFunds(token: string, clientId: string | number) {
@@ -101,6 +92,29 @@ function investInFund(token: string, fundId: string | number, accountNumber: str
   });
 }
 
+function withdrawFromFund(token: string, fundId: string | number, accountNumber: string, amount: number) {
+  return cy.request({
+    method: 'POST',
+    url: `${TRADING_API}/investment-funds/${fundId}/withdraw`,
+    headers: { Authorization: `Bearer ${token}` },
+    body: {
+      account_number: accountNumber,
+      amount,
+    },
+    failOnStatusCode: false,
+  });
+}
+
+function parsePercentFromCardText(cardText: string) {
+  const compact = cardText.replace(/\s+/g, ' ');
+  const match = compact.match(/Procenat:\s*([0-9.,]+)%/i);
+  if (!match) return null;
+
+  const normalized = match[1].replace(',', '.');
+  const parsed = Number(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 describe('Scenario 45: Procenat fonda klijenta se menja kada admin uplati u isti fond', () => {
   const anaEmail = 'ana.anic@example.com';
   const anaPassword = 'password123';
@@ -108,108 +122,182 @@ describe('Scenario 45: Procenat fonda klijenta se menja kada admin uplati u isti
   const adminEmail = 'admin@raf.rs';
   const adminPassword = 'admin123';
 
+  let rollbackFundId: string | number | null = null;
+  let rollbackAccountNumber = '';
+  let rollbackAmount = 0;
+  let shouldRollback = false;
+  let adminTokenForRollback = '';
+
+  beforeEach(() => {
+    rollbackFundId = null;
+    rollbackAccountNumber = '';
+    rollbackAmount = 0;
+    shouldRollback = false;
+    adminTokenForRollback = '';
+  });
+
+  afterEach(() => {
+    if (!shouldRollback || !rollbackFundId || !rollbackAccountNumber || !rollbackAmount || !adminTokenForRollback) {
+      return;
+    }
+
+    withdrawFromFund(
+      adminTokenForRollback,
+      rollbackFundId,
+      rollbackAccountNumber,
+      rollbackAmount
+    );
+  });
+
   it('procenat klijenta A se smanjuje nakon admin uplate u isti fond', () => {
     let anaToken = '';
-    let anaClientId: string | number;
+    let anaClientId: string | number = '';
     let adminToken = '';
 
-    let targetFundId: string | number;
-    let targetFundName = '';
-    let percentBefore = 0;
+    function pollAnaPortfolio(targetFundName: string, percentBefore: number, attempt = 0): Cypress.Chainable<any> {
+      return loginAndVisit(anaEmail, anaPassword, '/client/portfolio')
+        .then(() => {
+          cy.contains(/^Moji fondovi$/i).click();
 
-    // 1) Login kao Ana i uzmi Alpha Growth Fund
-    loginOnly(anaEmail, anaPassword).then((body) => {
-      anaToken = body.token;
-      anaClientId = getClientId(body.user);
+          return cy.contains(String(targetFundName))
+            .closest('[role="button"]')
+            .invoke('text');
+        })
+        .then((cardText) => {
+          const percentAfter = parsePercentFromCardText(cardText);
 
-      expect(anaClientId, 'Ana mora imati client id').to.exist;
-    });
+          expect(
+            percentAfter,
+            `Procenat mora biti prikazan i nakon admin uplate. Tekst kartice: ${cardText}`
+          ).to.not.equal(null);
 
-    cy.then(() => fetchClientFunds(anaToken, anaClientId)).then((res) => {
-      expect(res.status).to.eq(200);
+          if (Number(percentAfter) < Number(percentBefore)) {
+            return cy.wrap(Number(percentAfter));
+          }
 
-      const funds = pickArray(res.body);
-      expect(funds.length, 'Ana mora imati bar jedan fond').to.be.greaterThan(0);
+          if (attempt >= 8) {
+            throw new Error(`Procenat se nije smanjio. Pre: ${percentBefore}, posle: ${percentAfter}`);
+          }
 
-      const alphaFund = funds.find((f: any) => {
-        const name = getFundName(f).toLowerCase();
-        return name.includes('alpha growth fund');
-      });
+          return cy.wait(1000).then(() => pollAnaPortfolio(targetFundName, percentBefore, attempt + 1));
+        });
+    }
 
-      expect(alphaFund, 'Ana mora imati Alpha Growth Fund').to.exist;
+    return loginOnly(anaEmail, anaPassword)
+      .then((res) => {
+        expect(res.status).to.eq(200);
 
-      targetFundId = getFundId(alphaFund);
-      targetFundName = getFundName(alphaFund);
-      percentBefore = getFundPercent(alphaFund);
+        anaToken = res.body.token;
+        anaClientId = getClientId(res.body.user);
 
-      expect(targetFundId, 'Alpha Growth Fund mora imati id').to.exist;
-      expect(percentBefore, 'Početni procenat mora biti > 0').to.be.greaterThan(0);
-    });
+        expect(anaClientId, 'Ana mora imati client id').to.exist;
 
-    // 2) Login kao admin
-    loginOnly(adminEmail, adminPassword).then((body) => {
-      adminToken = body.token;
-    });
-
-    // 3) Admin ulaže 1000 u isti fond koristeći interni bankovni račun
-    cy.then(() => fetchAllBankAccounts(adminToken)).then((accountsRes) => {
-      expect(accountsRes.status).to.eq(200);
-
-      const bankAccounts = pickArray(accountsRes.body);
-      expect(bankAccounts.length, 'Moraju postojati bankovni računi').to.be.greaterThan(0);
-
-      const bankAccount = findInternalBankAccount(bankAccounts);
-      expect(
-        bankAccount,
-        'Mora postojati interni bankovni račun (AccountType=bank, CompanyID=1)'
-      ).to.exist;
-
-      const accountNumber = getAccountNumber(bankAccount);
-      expect(accountNumber, 'Interni bankovni račun mora imati broj').to.not.equal('');
-
-      return investInFund(adminToken, targetFundId, accountNumber, 2000);
-    }).then((investRes: any) => {
-      expect(
-        [200, 201],
-        `Admin uplata nije uspela: ${JSON.stringify(investRes.body)}`
-      ).to.include(investRes.status);
-    });
-
-    // 4) Poll dok se Ani ne smanji procenat
-    function pollAnaFunds(attempt = 0): Cypress.Chainable {
-      return cy.then(() => fetchClientFunds(anaToken, anaClientId)).then((res) => {
+        return fetchClientFunds(anaToken, anaClientId);
+      })
+      .then((res) => {
         expect(res.status).to.eq(200);
 
         const funds = pickArray(res.body);
-        const updatedFund = funds.find((f: any) => String(getFundId(f)) === String(targetFundId));
+        expect(funds.length, 'Ana mora imati bar jedan fond').to.be.greaterThan(0);
 
-        expect(updatedFund, 'Ciljni fond mora postojati kod Ane').to.exist;
+        const alphaFund = funds.find((f: any) => {
+          const name = getFundName(f).toLowerCase();
+          return name.includes('alpha growth fund');
+        });
 
-        const percentAfter = getFundPercent(updatedFund);
+        expect(alphaFund, 'Ana mora imati Alpha Growth Fund').to.exist;
 
-        if (percentAfter < percentBefore) {
-          expect(percentAfter, 'Procenat klijenta A treba da se smanji').to.be.lessThan(percentBefore);
-          return cy.wrap(updatedFund).as('updatedFund');
-        }
+        const targetFundId = getFundId(alphaFund);
+        const targetFundName = getFundName(alphaFund);
 
-        if (attempt >= 8) {
-          throw new Error(`Procenat se nije smanjio. Pre: ${percentBefore}, posle: ${percentAfter}`);
-        }
+        expect(targetFundId, 'Alpha Growth Fund mora imati id').to.exist;
+        expect(targetFundName, 'Alpha Growth Fund mora imati naziv').to.not.equal('');
 
-        cy.wait(1000);
-        return pollAnaFunds(attempt + 1);
+        cy.wrap(targetFundId).as('targetFundId');
+        cy.wrap(targetFundName).as('targetFundName');
+
+        return loginAndVisit(anaEmail, anaPassword, '/client/portfolio');
+      })
+      .then(() => {
+        cy.contains(/^Moji fondovi$/i).click();
+
+        return cy.get('@targetFundName').then((targetFundName) => {
+          return cy.contains(String(targetFundName))
+            .closest('[role="button"]')
+            .invoke('text');
+        });
+      })
+      .then((cardText) => {
+        const parsed = parsePercentFromCardText(cardText);
+
+        expect(
+          parsed,
+          `Procenat mora biti prikazan na UI kartici fonda. Tekst kartice: ${cardText}`
+        ).to.not.equal(null);
+
+        const percentBefore = Number(parsed);
+        expect(percentBefore, 'Početni procenat mora biti > 0').to.be.greaterThan(0);
+
+        cy.wrap(percentBefore).as('percentBefore');
+
+        return loginOnly(adminEmail, adminPassword);
+      })
+      .then((res) => {
+        expect(res.status).to.eq(200);
+
+        adminToken = res.body.token;
+        adminTokenForRollback = res.body.token;
+
+        return fetchAllBankAccounts(adminToken);
+      })
+      .then((accountsRes) => {
+        expect(accountsRes.status).to.eq(200);
+
+        const bankAccounts = pickArray(accountsRes.body);
+        expect(bankAccounts.length, 'Moraju postojati bankovni računi').to.be.greaterThan(0);
+
+        const bankAccount = findInternalBankAccount(bankAccounts);
+        expect(
+          bankAccount,
+          'Mora postojati interni bankovni račun (AccountType=bank, CompanyID=1)'
+        ).to.exist;
+
+        const accountNumber = getAccountNumber(bankAccount);
+        expect(accountNumber, 'Interni bankovni račun mora imati broj').to.not.equal('');
+
+        rollbackAccountNumber = accountNumber;
+        rollbackAmount = 20000;
+
+        return cy.get('@targetFundId').then((targetFundId: any) => {
+          const fundId = String(targetFundId);
+
+          rollbackFundId = fundId;
+          return investInFund(adminToken, fundId, accountNumber, 20000);
+        });
+      })
+      .then((investRes: any) => {
+        expect(
+          [200, 201],
+          `Admin uplata nije uspela: ${JSON.stringify(investRes.body)}`
+        ).to.include(investRes.status);
+
+        shouldRollback = true;
+
+        return cy.get('@targetFundName').then((targetFundName) => {
+          return cy.get('@percentBefore').then((percentBefore) => {
+            return pollAnaPortfolio(String(targetFundName), Number(percentBefore));
+          });
+        });
+      })
+      .then((updatedPercent) => {
+        expect(Number(updatedPercent)).to.be.greaterThan(0);
+
+        return cy.get('@targetFundName').then((targetFundName) => {
+          return loginAndVisit(anaEmail, anaPassword, '/client/portfolio').then(() => {
+            cy.contains(/^Moji fondovi$/i).click();
+            cy.contains(String(targetFundName)).should('be.visible');
+          });
+        });
       });
-    }
-
-    pollAnaFunds();
-
-    // 5) UI provera da se fond i dalje vidi Ani
-    loginAndVisit(anaEmail, anaPassword, '/portfolio');
-
-    cy.contains(/^Moji fondovi$/i).click();
-
-    cy.get('@updatedFund').then((fund: any) => {
-      cy.contains(getFundName(fund)).should('be.visible');
-    });
   });
 });

--- a/cypress/e2e/orders/scenario-40-supervisor-buys-security-for-fund.cy.ts
+++ b/cypress/e2e/orders/scenario-40-supervisor-buys-security-for-fund.cy.ts
@@ -1,10 +1,20 @@
 import { pickArray } from '../../support/helpers';
 
+function getDirectApiUrl(targetPort: 8080 | 8081 | 8082) {
+  const apiUrl = Cypress.env('API_URL');
+  if (!apiUrl) throw new Error('Missing Cypress env API_URL');
+
+  return apiUrl
+    .replace(':8080/api', `:${targetPort}/api`)
+    .replace(':8081/api', `:${targetPort}/api`)
+    .replace(':8082/api', `:${targetPort}/api`);
+}
+
 function loginAsSupervisor() {
   const apiUrl = Cypress.env('API_URL');
   if (!apiUrl) throw new Error('Missing Cypress env API_URL');
 
-  cy.request('POST', `${apiUrl}/auth/login`, {
+  cy.request('POST', `${getDirectApiUrl(8080)}/auth/login`, {
     email: 'admin@raf.rs',
     password: 'admin123',
   }).then((res) => {
@@ -51,14 +61,48 @@ function selectFirstRealAccountOption() {
     });
 }
 
+function extractOrderId(body: any) {
+  return (
+    body?.order_id ??
+    body?.id ??
+    body?.data?.order_id ??
+    body?.data?.id ??
+    null
+  );
+}
+
 describe('Scenario 40: Supervizor kupuje hartiju za investicioni fond', () => {
+  let supervisorToken: string | null = null;
+  let createdOrderId: string | null = null;
+
   beforeEach(() => {
+    supervisorToken = null;
+    createdOrderId = null;
+
     loginAsSupervisor();
+
+    cy.window().then((win) => {
+      supervisorToken = win.localStorage.getItem('token');
+    });
 
     cy.intercept('GET', '**/api/listings/stocks*').as('getStocks');
     cy.intercept('GET', '**/api/accounts*').as('getAccounts');
     cy.intercept('GET', '**/api/actuary/*/assets/funds*').as('getManagedFunds');
     cy.intercept('POST', '**/api/orders/invest').as('createFundOrder');
+  });
+
+  afterEach(() => {
+    if (!supervisorToken || !createdOrderId) return;
+
+    cy.request({
+      method: 'PATCH',
+      url: `${getDirectApiUrl(8082)}/orders/${createdOrderId}/cancel`,
+      headers: {
+        Authorization: `Bearer ${supervisorToken}`,
+      },
+      body: {},
+      failOnStatusCode: false,
+    });
   });
 
   it('kreira BUY order za fond i šalje ga preko /orders/invest', () => {
@@ -148,6 +192,8 @@ describe('Scenario 40: Supervizor kupuje hartiju za investicioni fond', () => {
       expect(request.body.quantity).to.eq(1);
       expect(request.body.fund_id).to.exist;
       expect(request.body.listing_id).to.exist;
+
+      createdOrderId = extractOrderId(response?.body);
     });
   });
 });

--- a/cypress/e2e/orders/scenario-41-supervisor-buys-security-for-bank.cy.ts
+++ b/cypress/e2e/orders/scenario-41-supervisor-buys-security-for-bank.cy.ts
@@ -1,10 +1,17 @@
 import { pickArray } from '../../support/helpers';
 
-function loginAsSupervisor() {
+function getDirectApiUrl(targetPort: 8080 | 8081 | 8082) {
   const apiUrl = Cypress.env('API_URL');
   if (!apiUrl) throw new Error('Missing Cypress env API_URL');
 
-  cy.request('POST', `${apiUrl}/auth/login`, {
+  return apiUrl
+    .replace(':8080/api', `:${targetPort}/api`)
+    .replace(':8081/api', `:${targetPort}/api`)
+    .replace(':8082/api', `:${targetPort}/api`);
+}
+
+function loginAsSupervisor() {
+  cy.request('POST', `${getDirectApiUrl(8080)}/auth/login`, {
     email: 'admin@raf.rs',
     password: 'admin123',
   }).then((res) => {
@@ -51,14 +58,48 @@ function selectFirstRealAccountOption() {
     });
 }
 
+function extractOrderId(body: any) {
+  return (
+    body?.order_id ??
+    body?.id ??
+    body?.data?.order_id ??
+    body?.data?.id ??
+    null
+  );
+}
+
 describe('Scenario 41: Supervizor kupuje hartiju za banku', () => {
+  let supervisorToken: string | null = null;
+  let createdOrderId: string | null = null;
+
   beforeEach(() => {
+    supervisorToken = null;
+    createdOrderId = null;
+
     loginAsSupervisor();
+
+    cy.window().then((win) => {
+      supervisorToken = win.localStorage.getItem('token');
+    });
 
     cy.intercept('GET', '**/api/listings/stocks*').as('getStocks');
     cy.intercept('GET', '**/api/accounts*').as('getAccounts');
     cy.intercept('POST', '**/api/orders').as('createBankOrder');
     cy.intercept('POST', '**/api/orders/invest').as('createFundOrder');
+  });
+
+  afterEach(() => {
+    if (!supervisorToken || !createdOrderId) return;
+
+    cy.request({
+      method: 'PATCH',
+      url: `${getDirectApiUrl(8082)}/orders/${createdOrderId}/cancel`,
+      headers: {
+        Authorization: `Bearer ${supervisorToken}`,
+      },
+      body: {},
+      failOnStatusCode: false,
+    });
   });
 
   it('šalje BUY order sa bankinog računa preko običnog /orders endpointa', () => {
@@ -109,6 +150,8 @@ describe('Scenario 41: Supervizor kupuje hartiju za banku', () => {
       expect(request.body.account_number).to.exist;
       expect(request.body.listing_id).to.exist;
       expect(request.body.fund_id).to.not.exist;
+
+      createdOrderId = extractOrderId(response?.body);
     });
 
     cy.get('@createFundOrder.all').should('have.length', 0);


### PR DESCRIPTION
stari pr, ignorisi

Dodati rollback mehanizmi za Cypress scenarije:
 - scenario 36
 - scenario 37
 - scenario 40
 - scenario 41
 - scenario 45

Za fund withdrawal/invest scenarije uveden afterEach rollback preko suprotne operacije gde je moguće. Za order scenarije uvedeno čuvanje kreiranog resursa i cleanup na kraju testa.

Za scenario 38 i dalje ne može da ima čist rollback jer backend nema endpoint za brisanje/deaktivaciju kreiranog fonda.