### PR TITLE
hotfix(ci): remove timeout for cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -42,7 +42,6 @@ jobs:
         run: cp .github/workflows/cypress.env.test.json cypress.env.json && cp .github/workflows/.env.test .env
 
       - name: Run Cypress
-        timeout-minutes: 30
         uses: cypress-io/github-action@783cb3f07983868532cabaedaa1e6c00ff4786a8
         with:
           start: npm run dev


### PR DESCRIPTION
The end-to-end tests didn't complete because of a timeout that was set before for troubleshooting.