### PR TITLE
Dividend todo

### DIFF
--- a/src/api/endpoints/dividends.js
+++ b/src/api/endpoints/dividends.js
@@ -1,0 +1,18 @@
+import { tradingApi as api } from '../client';
+
+export const dividendsApi = {
+  getPortfolioDividends: (assetOwnershipId) =>
+    api.get(`/portfolio/assets/${assetOwnershipId}/dividends`),
+
+  getClientDividends: (clientId, assetOwnershipId) =>
+    api.get(`/client/${clientId}/assets/${assetOwnershipId}/dividends`),
+
+  getActuaryDividends: (actId, assetOwnershipId) =>
+    api.get(`/actuary/${actId}/assets/${assetOwnershipId}/dividends`),
+
+  getAllDividends: () =>
+    api.get('/dividends'),
+
+  triggerDividends: () =>
+    api.post('/dividends/trigger'),
+};

--- a/src/features/portfolio/DividendHistoryModal.jsx
+++ b/src/features/portfolio/DividendHistoryModal.jsx
@@ -62,7 +62,7 @@ function normalizeRows(payload) {
   }));
 }
 
-export default function DividendHistoryModal({ open, asset, onClose }) {
+export default function DividendHistoryModal({ open, asset, clientId, actId, onClose }) {
   const [loading, setLoading] = useState(false);
   const [rows, setRows] = useState([]);
   const [error, setError] = useState('');
@@ -87,16 +87,32 @@ export default function DividendHistoryModal({ open, asset, onClose }) {
       setLoading(true);
       setError('');
 
-      const res = await dividendsApi.getPortfolioDividends(assetOwnershipId);
+      let res;
+
+      if (clientId) {
+        res = await dividendsApi.getClientDividends(clientId, assetOwnershipId);
+      } else if (actId) {
+        res = await dividendsApi.getActuaryDividends(actId, assetOwnershipId);
+      } else {
+        setError('Nedostaje clientId ili actId za učitavanje dividendi.');
+        setRows([]);
+        return;
+      }
+
       const raw = res?.data ?? res;
       setRows(normalizeRows(raw));
     } catch (err) {
-      setError(
-        err?.response?.data?.message ??
-        err?.message ??
-        'Greška pri učitavanju istorije dividendi.'
-      );
-      setRows([]);
+      if (err?.response?.status === 404) {
+        setRows([]);
+        setError('');
+      } else {
+        setError(
+          err?.response?.data?.message ??
+          err?.message ??
+          'Greška pri učitavanju istorije dividendi.'
+        );
+        setRows([]);
+      }
     } finally {
       setLoading(false);
     }

--- a/src/features/portfolio/DividendHistoryModal.jsx
+++ b/src/features/portfolio/DividendHistoryModal.jsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react';
+import { dividendsApi } from '../../api/endpoints/dividends';
+import styles from './DividendHistoryModal.module.css';
+
+function pickArray(body) {
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.data)) return body.data;
+  if (Array.isArray(body?.items)) return body.items;
+  if (Array.isArray(body?.content)) return body.content;
+  return [];
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+
+  try {
+    return new Intl.DateTimeFormat('sr-RS', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+function formatAmount(value, currencyCode = 'RSD') {
+  if (value === null || value === undefined || value === '') return '—';
+
+  const amount = Number(value);
+  if (Number.isNaN(amount)) return String(value);
+
+  try {
+    return new Intl.NumberFormat('sr-RS', {
+      style: 'currency',
+      currency: currencyCode,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toLocaleString('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })} ${currencyCode}`;
+  }
+}
+
+function normalizeRows(payload) {
+  return pickArray(payload).map((item, index) => ({
+    id:
+      item.dividendPayoutId ??
+      item.dividend_payout_id ??
+      `${item.paymentDate ?? item.payment_date ?? 'row'}-${index}`,
+    stock: item.stock ?? item.ticker ?? '—',
+    quantity: item.quantity ?? '—',
+    grossAmount: item.grossAmount ?? item.gross_amount ?? 0,
+    taxAmount: item.taxAmount ?? item.tax_amount ?? item.tax ?? 0,
+    netAmount: item.netAmount ?? item.net_amount ?? 0,
+    paymentDate: item.paymentDate ?? item.payment_date,
+    accountNumber: item.accountNumber ?? item.account_number ?? '—',
+    currencyCode: item.currencyCode ?? item.currency_code ?? item.currency ?? 'RSD',
+  }));
+}
+
+export default function DividendHistoryModal({ open, asset, onClose }) {
+  const [loading, setLoading] = useState(false);
+  const [rows, setRows] = useState([]);
+  const [error, setError] = useState('');
+
+  const assetOwnershipId =
+    asset?.ownership_id ??
+    asset?.asset_ownership_id ??
+    asset?.ownershipId ??
+    asset?.assetOwnershipId ??
+    asset?.id;
+
+  const title = asset?.ticker ?? asset?.name ?? 'Pozicija';
+
+  const loadData = async () => {
+    if (!assetOwnershipId) {
+      setError('Nije pronađen ownership ID za ovu poziciju.');
+      setRows([]);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError('');
+
+      const res = await dividendsApi.getPortfolioDividends(assetOwnershipId);
+      const raw = res?.data ?? res;
+      setRows(normalizeRows(raw));
+    } catch (err) {
+      setError(
+        err?.response?.data?.message ??
+        err?.message ??
+        'Greška pri učitavanju istorije dividendi.'
+      );
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, assetOwnershipId]);
+
+  const totalNet = useMemo(
+    () => rows.reduce((sum, row) => sum + Number(row.netAmount || 0), 0),
+    [rows]
+  );
+
+  const totalTax = useMemo(
+    () => rows.reduce((sum, row) => sum + Number(row.taxAmount || 0), 0),
+    [rows]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dividend-history-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.header}>
+          <div>
+            <div className={styles.eyebrow}>Dividend history</div>
+            <h2 id="dividend-history-title" className={styles.title}>
+              Primljene dividende — {title}
+            </h2>
+          </div>
+
+          <button type="button" className={styles.closeBtn} onClick={onClose}>
+            Zatvori
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          {error ? (
+            <div className={styles.errorBox}>{error}</div>
+          ) : loading ? (
+            <div className={styles.stateBox}>Učitavanje dividendi…</div>
+          ) : rows.length === 0 ? (
+            <div className={styles.stateBox}>Nema primljenih dividendi za ovu poziciju.</div>
+          ) : (
+            <>
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>Datum isplate</th>
+                      <th>Akcija</th>
+                      <th>Količina</th>
+                      <th>Bruto iznos</th>
+                      <th>Porez</th>
+                      <th>Neto iznos</th>
+                      <th>Račun</th>
+                      <th>Valuta</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row) => (
+                      <tr key={row.id}>
+                        <td>{formatDate(row.paymentDate)}</td>
+                        <td>{row.stock}</td>
+                        <td>{row.quantity}</td>
+                        <td>{formatAmount(row.grossAmount, row.currencyCode)}</td>
+                        <td className={Number(row.taxAmount) > 0 ? styles.negative : styles.muted}>
+                          {formatAmount(row.taxAmount, 'RSD')}
+                        </td>
+                        <td className={styles.positive}>
+                          {formatAmount(row.netAmount, row.currencyCode)}
+                        </td>
+                        <td>{row.accountNumber}</td>
+                        <td>{row.currencyCode}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className={styles.summaryRow}>
+                <div className={styles.summaryBox}>
+                  <div className={styles.summaryLabel}>Ukupno neto</div>
+                  <div className={styles.positive}>
+                    {formatAmount(totalNet, rows[0]?.currencyCode ?? 'RSD')}
+                  </div>
+                </div>
+
+                <div className={styles.summaryBox}>
+                  <div className={styles.summaryLabel}>Ukupan porez</div>
+                  <div className={styles.negative}>
+                    {formatAmount(totalTax, 'RSD')}
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/portfolio/DividendHistoryModal.module.css
+++ b/src/features/portfolio/DividendHistoryModal.module.css
@@ -1,0 +1,150 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.48);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1200;
+}
+
+.modal {
+  width: min(960px, 100%);
+  max-height: 88vh;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  box-shadow: 0 25px 80px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.eyebrow {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 26px;
+  line-height: 1.15;
+  color: #0f172a;
+  font-weight: 800;
+}
+
+.closeBtn {
+  border: 1px solid #dbe2ea;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.closeBtn:hover {
+  background: #f8fafc;
+}
+
+.body {
+  padding: 20px 24px 24px;
+  overflow: auto;
+}
+
+.stateBox {
+  padding: 20px;
+  text-align: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.errorBox {
+  padding: 16px;
+  border: 1px solid #fecaca;
+  border-radius: 14px;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.tableWrap {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+.table thead th {
+  text-align: left;
+  padding: 14px 16px;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.table tbody td {
+  padding: 16px;
+  border-bottom: 1px solid #eef2f7;
+  color: #0f172a;
+  font-size: 14px;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.summaryRow {
+  margin-top: 16px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.summaryBox {
+  min-width: 180px;
+}
+
+.summaryLabel {
+  color: #64748b;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.positive {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.negative {
+  color: #b91c1c;
+  font-weight: 700;
+}
+
+.muted {
+  color: #64748b;
+}

--- a/src/features/portfolio/PortfolioTable.jsx
+++ b/src/features/portfolio/PortfolioTable.jsx
@@ -4,10 +4,15 @@ import styles from './PortfolioTable.module.css';
 
 const PAGE_SIZE = 10;
 
-export default function PortfolioTable({ assets, isAdmin, onSell, onPublish }) {
+export default function PortfolioTable({ assets, isAdmin, onSell, onPublish, onViewDividends}) {
   const [page, setPage] = useState(1);
   const [qtyMap, setQtyMap] = useState({});
   const paged = assets.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+    const getDividendYield = (asset) =>
+    asset?.dividend_yield ??
+    asset?.dividendYield ??
+    asset?.DividendYield ??
+    null;
 
   return (
     <div className={styles.tableWrap}>
@@ -19,14 +24,16 @@ export default function PortfolioTable({ assets, isAdmin, onSell, onPublish }) {
             <th>AMOUNT</th>
             <th>PRICE</th>
             <th>PROFIT</th>
+            <th>DIVIDEND YIELD</th>
             <th>LAST MODIFIED</th>
+            <th>DIVIDENDE</th>
             <th>ACTIONS</th>
           </tr>
         </thead>
         <tbody>
           {paged.length === 0 && (
             <tr>
-              <td colSpan="7" style={{ textAlign: 'center', padding: '24px', color: 'var(--tx-3)' }}>
+              <td colSpan="9" style={{ textAlign: 'center', padding: '24px', color: 'var(--tx-3)' }}>                
                 Nema hartija za prikaz.
               </td>
             </tr>
@@ -42,11 +49,30 @@ export default function PortfolioTable({ assets, isAdmin, onSell, onPublish }) {
                   ? `${Number(asset.pricePerUnitRSD).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} RSD`
                   : asset.price != null ? `$${asset.price}` : '—'}
                 </td>
-                <td className={asset.profit >= 0 ? styles.pos : styles.neg}>
+                                <td className={asset.profit >= 0 ? styles.pos : styles.neg}>
                   {asset.profit >= 0 ? '+' : ''}{Number(asset.profit ?? 0).toLocaleString('sr-RS', { minimumFractionDigits: 2 })}
+                </td>
+                <td>
+                  {getDividendYield(asset) != null
+                    ? `${Number(getDividendYield(asset)).toLocaleString('sr-RS', {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}%`
+                    : '—'}
                 </td>
                 <td style={{ color: '#64748b', fontSize: '12px' }}>
                   {asset.lastModified ? new Date(asset.lastModified).toLocaleDateString('sr-RS') : '—'}
+                </td>
+                <td>
+                  {String(asset.type ?? '').toUpperCase() === 'STOCK' ? (
+                    <button
+                      type="button"
+                      className={styles.dividendBtn}
+                      onClick={() => onViewDividends?.(asset)}
+                    >
+                      Dividende
+                    </button>
+                  ) : '—'}
                 </td>
                 <td>
                   <div className={styles.actionCell}>

--- a/src/features/portfolio/PortfolioTable.module.css
+++ b/src/features/portfolio/PortfolioTable.module.css
@@ -136,3 +136,20 @@
   align-items: center; 
   justify-content: center; /* Dodaj ovo da se dugmići centriraju u odnosu na naslov */
 }
+
+.dividendBtn {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.dividendBtn:hover {
+  background: #f8fafc;
+  border-color: #94a3b8;
+}

--- a/src/features/securities/SecuritiesTable.jsx
+++ b/src/features/securities/SecuritiesTable.jsx
@@ -9,6 +9,7 @@ const SORT_KEYS = {
   price: 'price',
   volume: 'volume',
   maintenanceMargin: 'maintenanceMargin',
+  dividendYield: 'dividendYield',
 };
 
 function SortIcon({ col, sortBy, sortDir }) {
@@ -36,6 +37,10 @@ function Th({ col, children, sortBy, sortDir, onSort }) {
   );
 }
 
+function activeTabSupportsDividendYield(securities) {
+  return securities.length > 0 && securities[0].type === 'STOCK';
+}
+
 function fmt(n, decimals = 2) {
   if (n == null) return '—';
   return new Intl.NumberFormat('sr-RS', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }).format(n);
@@ -54,6 +59,14 @@ function fmtVol(n) {
   if (n >= 1_000_000)     return (n / 1_000_000).toFixed(2) + 'M';
   if (n >= 1_000)         return (n / 1_000).toFixed(1) + 'K';
   return n.toString();
+}
+
+function fmtYield(n) {
+  if (n == null) return '—';
+  return `${new Intl.NumberFormat('sr-RS', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n)}%`;
 }
 
 export default function SecuritiesTable({
@@ -109,6 +122,16 @@ export default function SecuritiesTable({
             {(isOption || isFutures) && <th className={styles.th}>Datum isteka</th>}
             {!isOption && <Th col="maintenanceMargin" sortBy={sortBy} sortDir={sortDir} onSort={onSort}>Maint. Margin</Th>}
             {!isOption && <th className={styles.th}>Init. Margin Cost</th>}
+            {activeTabSupportsDividendYield(securities) && (
+              <Th
+                col={SORT_KEYS.dividendYield}
+                sortBy={sortBy}
+                sortDir={sortDir}
+                onSort={onSort}
+              >
+                Dividend Yield
+              </Th>
+            )}
             {onAction && <th className={styles.th}></th>}
             <th className={styles.th}></th>
           </tr>
@@ -161,6 +184,9 @@ export default function SecuritiesTable({
                 </td>
                 )}
                 {!isOption && <td className={styles.td}>{fmt(sec.initialMarginCost)}</td>}
+                {sec.type === 'STOCK' && (
+                  <td className={styles.td}>{fmtYield(sec.dividend_yield ?? sec.dividendYield)}</td>
+                )}
                 {onAction && (
                   <td className={styles.td} onClick={e => e.stopPropagation()} style={{ whiteSpace: 'nowrap' }}>
                     <button

--- a/src/pages/admin/PortfolioPage.jsx
+++ b/src/pages/admin/PortfolioPage.jsx
@@ -127,6 +127,7 @@ export default function PortfolioPage() {
         />
       )}
 
+
       <DividendHistoryModal
         open={!!dividendModalAsset}
         asset={dividendModalAsset}

--- a/src/pages/admin/PortfolioPage.jsx
+++ b/src/pages/admin/PortfolioPage.jsx
@@ -13,6 +13,7 @@ import { portfolioApi } from '../../api/endpoints/portfolio';
 import { otcApi } from '../../api/endpoints/otc';
 import SellOrderModal from '../../features/portfolio/SellOrderModal';
 import styles from './PortfolioPage.module.css';
+import DividendHistoryModal from '../../features/portfolio/DividendHistoryModal';
 
 
 export default function PortfolioPage() {
@@ -30,6 +31,7 @@ export default function PortfolioPage() {
   });
   const [, setLoading] = useState(false);
   const [sellModal, setSellModal] = useState(null);
+  const [dividendModalAsset, setDividendModalAsset] = useState(null);
   const [activeTab, setActiveTab] = useState('securities');
   const [publishLoading, setPublishLoading] = useState(null);
   const [publishError, setPublishError]     = useState('');
@@ -124,6 +126,13 @@ export default function PortfolioPage() {
           onSuccess={() => setSellModal(null)}
         />
       )}
+
+      <DividendHistoryModal
+        open={!!dividendModalAsset}
+        asset={dividendModalAsset}
+        onClose={() => setDividendModalAsset(null)}
+      />
+
       <main className={styles.sadrzaj}>
         
         <div className="page-anim">
@@ -163,6 +172,7 @@ export default function PortfolioPage() {
                 assets={data.stocks}
                 isAdmin={canManageOTC}
                 onSell={asset => setSellModal(asset)}
+                onViewDividends={asset => setDividendModalAsset(asset)}
                 onPublish={async (asset, qty) => {
                   const ownershipId = asset.ownership_id ?? asset.asset_ownership_id ?? asset.ownershipId ?? asset.assetId ?? asset.id;
                   if (!ownershipId) {

--- a/src/pages/admin/PortfolioPage.jsx
+++ b/src/pages/admin/PortfolioPage.jsx
@@ -130,6 +130,7 @@ export default function PortfolioPage() {
       <DividendHistoryModal
         open={!!dividendModalAsset}
         asset={dividendModalAsset}
+        actId={employeeId}
         onClose={() => setDividendModalAsset(null)}
       />
 

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -13,6 +13,7 @@ import ClientFundsTab from '../../features/portfolio/ClientFundsTab';
 import Spinner from '../../components/ui/Spinner';
 import Alert from '../../components/ui/Alert';
 import styles from './ClientPortfolioPage.module.css';
+import DividendHistoryModal from '../../features/portfolio/DividendHistoryModal';
 
 export default function ClientPortfolioPage() {
   const pageRef = useRef(null);
@@ -21,6 +22,7 @@ export default function ClientPortfolioPage() {
   const [loading, setLoading]     = useState(true);
   const [error, setError]         = useState(null);
   const [sellModal, setSellModal] = useState(null);
+  const [dividendModalAsset, setDividendModalAsset] = useState(null);
   const [activeTab, setActiveTab] = useState('securities');
   const [publishError, setPublishError] = useState('');
   const [publishSuccess, setPublishSuccess] = useState('');
@@ -106,6 +108,12 @@ export default function ClientPortfolioPage() {
         />
       )}
 
+      <DividendHistoryModal
+        open={!!dividendModalAsset}
+        asset={dividendModalAsset}
+        onClose={() => setDividendModalAsset(null)}
+      />
+
       <main className={styles.sadrzaj}>
         <div className="page-anim">
           <div className={styles.breadcrumb}><span>Moj nalog</span></div>
@@ -163,6 +171,7 @@ export default function ClientPortfolioPage() {
                     assets={portfolio.stocks}
                     isAdmin={true}
                     onSell={asset => setSellModal(asset)}
+                    onViewDividends={asset => setDividendModalAsset(asset)}
                     onPublish={async (asset, qty) => {
                       const ownershipId = asset.ownership_id ?? asset.asset_ownership_id ?? asset.ownershipId ?? asset.id;
                       if (!ownershipId) { setPublishError('Nije pronađen ownershipId.'); return; }

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -111,6 +111,7 @@ export default function ClientPortfolioPage() {
       <DividendHistoryModal
         open={!!dividendModalAsset}
         asset={dividendModalAsset}
+        clientId={clientId}
         onClose={() => setDividendModalAsset(null)}
       />
 


### PR DESCRIPTION
Issue #162 

- dodat prikaz Dividend Yield za akcije na strani Hartije od vrednosti
- dodat Dividende action u Moj Portfolio tabeli
- uveden DividendHistoryModal za prikaz istorije isplata po konkretnoj poziciji
- klijentski portfolio povezan na GET /api/client/{clientId}/assets/{assetOwnershipId}/dividends
- aktuarski/supervizorski portfolio povezan na GET /api/actuary/{actId}/assets/{assetOwnershipId}/dividends
- uklonjeno oslanjanje na generički /api/portfolio/assets/{assetOwnershipId}/dividends jer backend ruta ne radi kako swagger tvrdi (404)
- potvrđeno ručno da prikaz radi ispravno kada akcija ima dividend_yield > 0