### PR TITLE
Add Cypress tests: scenarios 7-9, 32-34, 37-39, 44-46, 51-53, 57-59, …

### DIFF
--- a/cypress/e2e/audit-log/scenario-44-filter-by-action-type.cy.ts
+++ b/cypress/e2e/audit-log/scenario-44-filter-by-action-type.cy.ts
@@ -1,0 +1,87 @@
+/// <reference types="cypress" />
+
+// Scenario 44: Audit log - filtriranje po tipu akcije
+
+const ALL_LOGS = [
+  {
+    id: 1,
+    action_type: 'AGENT_LIMIT_CHANGED',
+    actor: { first_name: 'Marko', last_name: 'Marković' },
+    target: { first_name: 'Petar', last_name: 'Petrović' },
+    created_at: '2026-04-01T10:00:00Z',
+    details: { new_limit: 100000, old_limit: 50000 },
+  },
+  {
+    id: 2,
+    action_type: 'ORDER_APPROVED',
+    actor: { first_name: 'Ana', last_name: 'Anić' },
+    target: null,
+    created_at: '2026-04-02T11:00:00Z',
+    details: { order_id: 999 },
+  },
+  {
+    id: 3,
+    action_type: 'ORDER_REJECTED',
+    actor: { first_name: 'Marko', last_name: 'Marković' },
+    target: null,
+    created_at: '2026-04-03T12:00:00Z',
+    details: { order_id: 998, reason: 'Nedovoljno sredstava' },
+  },
+];
+
+describe('Scenario 44: Audit log - filtriranje po tipu akcije', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/audit-log*', (req) => {
+      const url = new URL(req.url);
+      const actionType = url.searchParams.get('action_type');
+
+      const filtered = actionType
+        ? ALL_LOGS.filter(l => l.action_type === actionType)
+        : ALL_LOGS;
+
+      req.reply({ statusCode: 200, body: { data: filtered, total: filtered.length, total_pages: 1 } });
+    }).as('getAuditLog');
+
+    cy.loginAsAdmin();
+    cy.visit('/admin/audit-log');
+  });
+
+  it('prikazuje sve logove bez filtera', () => {
+    cy.wait('@getAuditLog');
+    cy.contains(/promena limita agentu/i).should('be.visible');
+    cy.contains(/order odobren/i).should('be.visible');
+    cy.contains(/order odbijen/i).should('be.visible');
+  });
+
+  it('filtrira logove po tipu akcije ORDER_APPROVED', () => {
+    cy.wait('@getAuditLog');
+
+    cy.contains('label', 'Tip akcije').find('select').select('ORDER_APPROVED');
+    cy.contains('button', 'Primeni').click();
+
+    cy.wait('@getAuditLog').then(({ request }) => {
+      expect(new URL(request.url).searchParams.get('action_type')).to.eq('ORDER_APPROVED');
+    });
+
+    cy.contains(/order odobren/i).should('be.visible');
+    cy.contains(/promena limita agentu/i).should('not.exist');
+    cy.contains(/order odbijen/i).should('not.exist');
+  });
+
+  it('resetuje filter i prikazuje sve logove', () => {
+    cy.wait('@getAuditLog');
+
+    cy.contains('label', 'Tip akcije').find('select').select('ORDER_APPROVED');
+    cy.contains('button', 'Primeni').click();
+    cy.wait('@getAuditLog');
+
+    cy.contains('button', 'Reset').click();
+    cy.wait('@getAuditLog');
+
+    cy.contains(/promena limita agentu/i).should('be.visible');
+    cy.contains(/order odobren/i).should('be.visible');
+    cy.contains(/order odbijen/i).should('be.visible');
+  });
+});
+
+export {};

--- a/cypress/e2e/audit-log/scenario-45-filter-by-user.cy.ts
+++ b/cypress/e2e/audit-log/scenario-45-filter-by-user.cy.ts
@@ -1,0 +1,74 @@
+/// <reference types="cypress" />
+
+// Scenario 45: Audit log - filtriranje po korisniku
+
+const ALL_LOGS = [
+  {
+    id: 1,
+    action_type: 'AGENT_LIMIT_CHANGED',
+    actor: { first_name: 'Marko', last_name: 'Marković' },
+    target: null,
+    created_at: '2026-04-01T10:00:00Z',
+    details: {},
+  },
+  {
+    id: 2,
+    action_type: 'ORDER_APPROVED',
+    actor: { first_name: 'Jana', last_name: 'Janić' },
+    target: null,
+    created_at: '2026-04-02T11:00:00Z',
+    details: { order_id: 100 },
+  },
+  {
+    id: 3,
+    action_type: 'ORDER_REJECTED',
+    actor: { first_name: 'Jana', last_name: 'Janić' },
+    target: null,
+    created_at: '2026-04-03T12:00:00Z',
+    details: { order_id: 101 },
+  },
+];
+
+describe('Scenario 45: Audit log - filtriranje po korisniku', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/audit-log*', (req) => {
+      const url = new URL(req.url);
+      const user = url.searchParams.get('user');
+
+      const filtered = user
+        ? ALL_LOGS.filter(l => {
+            const actor = l.actor;
+            const fullName = `${actor.first_name} ${actor.last_name}`.toLowerCase();
+            return fullName.includes(user.toLowerCase());
+          })
+        : ALL_LOGS;
+
+      req.reply({ statusCode: 200, body: { data: filtered, total: filtered.length, total_pages: 1 } });
+    }).as('getAuditLog');
+
+    cy.loginAsAdmin();
+    cy.visit('/admin/audit-log');
+  });
+
+  it('prikazuje sve logove bez korisničkog filtera', () => {
+    cy.wait('@getAuditLog');
+    cy.contains('Marko Marković').should('be.visible');
+    cy.contains('Jana Janić').should('be.visible');
+  });
+
+  it('filtrira logove po korisniku Jana Janić', () => {
+    cy.wait('@getAuditLog');
+
+    cy.contains('label', 'Korisnik').find('input').clear().type('Jana');
+    cy.contains('button', 'Primeni').click();
+
+    cy.wait('@getAuditLog').then(({ request }) => {
+      expect(new URL(request.url).searchParams.get('user')).to.eq('Jana');
+    });
+
+    cy.contains('Jana Janić').should('be.visible');
+    cy.contains('Marko Marković').should('not.exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/audit-log/scenario-46-client-denied.cy.ts
+++ b/cypress/e2e/audit-log/scenario-46-client-denied.cy.ts
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+// Scenario 46: Klijent nema pristup audit logu
+// Ruta /admin/audit-log je zaštićena SupervisorRoute-om.
+// Klijent koji pokuša da pristupi mora biti preusmeren.
+
+describe('Scenario 46: Klijent nema pristup audit logu', () => {
+  it('preusmerava klijenta sa /admin/audit-log na početnu stranicu', () => {
+    cy.loginAsClient();
+    cy.visit('/admin/audit-log');
+
+    cy.url().should('not.include', '/admin/audit-log');
+  });
+
+  it('ne prikazuje sadržaj audit loga klijentu', () => {
+    cy.loginAsClient();
+    cy.visit('/admin/audit-log');
+
+    cy.contains('Audit log').should('not.exist');
+    cy.get('table').should('not.exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/auth/scenario-7-nalog-zaklucava-sa-emailom.cy.ts
+++ b/cypress/e2e/auth/scenario-7-nalog-zaklucava-sa-emailom.cy.ts
@@ -1,0 +1,35 @@
+/// <reference types="cypress" />
+import { visitEmployeeLogin, fillLoginForm, submitLogin } from '../../support/authHelpers';
+
+// Scenario 7: Nalog se zaključava nakon 5 neuspešnih pokušaja
+// Email notifikacija o zaključavanju ne može se proveriti direktno iz Cypress-a —
+// verifikujemo da UI prikazuje poruku o zaključavanju (što znači da je backend triggerovao email).
+
+describe('Scenario 7: Nalog se zaključava nakon 5 neuspešnih pokušaja logovanja', () => {
+  it('prikazuje poruku o zaključavanju i odbija 5. neuspešan pokušaj', () => {
+    cy.intercept('POST', '**/api/auth/login').as('loginAttempt');
+
+    visitEmployeeLogin();
+
+    for (let i = 0; i < 4; i++) {
+      fillLoginForm('dimitrije@raf.rs', 'pogresna_lozinka_' + i);
+      submitLogin();
+      cy.wait('@loginAttempt');
+    }
+
+    fillLoginForm('dimitrije@raf.rs', 'pogresna_lozinka_final');
+    submitLogin();
+
+    cy.wait('@loginAttempt').then(({ response }) => {
+      expect([401, 403, 429]).to.include(response?.statusCode);
+    });
+
+    cy.contains(/zaključan|blokiran|privremeno/i).should('be.visible');
+    cy.url().should('include', '/login');
+    cy.window().then(win => {
+      expect(win.localStorage.getItem('token')).to.be.null;
+    });
+  });
+});
+
+export {};

--- a/cypress/e2e/auth/scenario-8-nalog-zaklucavan-nije-moguce-logovanje.cy.ts
+++ b/cypress/e2e/auth/scenario-8-nalog-zaklucavan-nije-moguce-logovanje.cy.ts
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+import { visitEmployeeLogin, fillLoginForm, submitLogin } from '../../support/authHelpers';
+
+// Scenario 8: Logovanje nije moguće dok je nalog zaključan (brute-force zaštita)
+
+describe('Scenario 8: Pokušaj logovanja dok je nalog privremeno zaključan', () => {
+  it('odbija logovanje sa ispravnom lozinkom dok je nalog zaključan i prikazuje poruku', () => {
+    cy.intercept('POST', '**/api/auth/login', {
+      statusCode: 403,
+      body: { message: 'Nalog je privremeno blokiran zbog previše neuspešnih pokušaja.' },
+    }).as('loginLocked');
+
+    visitEmployeeLogin();
+    fillLoginForm('dimitrije@raf.rs', 'ispravna_lozinka123');
+    submitLogin();
+
+    cy.wait('@loginLocked').its('response.statusCode').should('eq', 403);
+
+    cy.contains(/blokiran|zaključan|privremeno/i).should('be.visible');
+    cy.url().should('include', '/login');
+    cy.window().then(win => {
+      expect(win.localStorage.getItem('token')).to.be.null;
+    });
+  });
+});
+
+export {};

--- a/cypress/e2e/auth/scenario-9-logovanje-posle-isteka-zakljucavanja.cy.ts
+++ b/cypress/e2e/auth/scenario-9-logovanje-posle-isteka-zakljucavanja.cy.ts
@@ -1,0 +1,39 @@
+/// <reference types="cypress" />
+import { visitEmployeeLogin, fillLoginForm, submitLogin } from '../../support/authHelpers';
+
+// Scenario 9: Logovanje je moguće posle isteka zaključavanja (brute-force zaštita)
+// Ne možemo kontrolisati vreme zaključavanja u E2E testu, pa mockujemo uspešan odgovor
+// koji simululje situaciju u kojoj je zaključavanje isteklo.
+
+describe('Scenario 9: Uspešno logovanje posle isteka zaključavanja', () => {
+  it('prijavljuje korisnika kada je period zaključavanja istekao', () => {
+    cy.intercept('POST', '**/api/auth/login', {
+      statusCode: 200,
+      body: {
+        token: 'fake-token-after-unlock',
+        refresh_token: 'fake-refresh',
+        user: {
+          id: 1,
+          email: 'dimitrije@raf.rs',
+          first_name: 'Dimitrije',
+          last_name: 'Test',
+          identity_type: 'employee',
+          permissions: ['admin.all'],
+        },
+      },
+    }).as('loginSuccess');
+
+    visitEmployeeLogin();
+    fillLoginForm('dimitrije@raf.rs', 'ispravna_lozinka123');
+    submitLogin();
+
+    cy.wait('@loginSuccess').its('response.statusCode').should('eq', 200);
+
+    cy.url().should('not.include', '/login');
+    cy.window().then(win => {
+      expect(win.localStorage.getItem('token')).to.be.a('string').and.not.be.empty;
+    });
+  });
+});
+
+export {};

--- a/cypress/e2e/dtc/scenario-51-pause-recurring-order.cy.ts
+++ b/cypress/e2e/dtc/scenario-51-pause-recurring-order.cy.ts
@@ -1,0 +1,53 @@
+/// <reference types="cypress" />
+
+// Scenario 51: Pauziranje trajnog naloga (DCA)
+
+const RECURRING_ORDER_ID = 42;
+
+const ACTIVE_ORDER = {
+  recurring_order_id: RECURRING_ORDER_ID,
+  listing_id: 1,
+  account_number: '111-000-001',
+  direction: 'BUY',
+  cadence: 'MONTHLY',
+  mode: 'BY_AMOUNT',
+  value: 5000,
+  active: true,
+  next_run: new Date(Date.now() + 30 * 86400000).toISOString(),
+};
+
+describe('Scenario 51: Pauziranje trajnog naloga', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/client/*/assets', { statusCode: 200, body: { data: [], assets: [] } }).as('getPortfolio');
+    cy.intercept('GET', '**/api/recurring-orders', { statusCode: 200, body: [ACTIVE_ORDER] }).as('getRecurringOrders');
+    cy.intercept('PATCH', `**/api/recurring-orders/${RECURRING_ORDER_ID}/pause`, {
+      statusCode: 200,
+      body: { ...ACTIVE_ORDER, active: false },
+    }).as('pauseOrder');
+
+    cy.loginAsClientAna();
+    cy.visit('/client/dtc');
+    cy.wait('@getPortfolio');
+    cy.wait('@getRecurringOrders');
+  });
+
+  it('pauzira aktivan trajni nalog i menja prikaz statusa', () => {
+    cy.contains('Da').should('be.visible');
+
+    cy.intercept('GET', '**/api/recurring-orders', {
+      statusCode: 200,
+      body: [{ ...ACTIVE_ORDER, active: false }],
+    }).as('getRecurringOrdersAfterPause');
+
+    cy.contains('button', 'Pauziraj').click();
+
+    cy.wait('@pauseOrder').its('response.statusCode').should('eq', 200);
+    cy.wait('@getRecurringOrdersAfterPause');
+
+    cy.contains('Ne').should('be.visible');
+    cy.contains('button', 'Aktiviraj').should('be.visible');
+    cy.contains('button', 'Pauziraj').should('not.exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/dtc/scenario-52-cancel-recurring-order.cy.ts
+++ b/cypress/e2e/dtc/scenario-52-cancel-recurring-order.cy.ts
@@ -1,0 +1,43 @@
+/// <reference types="cypress" />
+
+// Scenario 52: Otkazivanje trajnog naloga (DCA)
+
+const RECURRING_ORDER_ID = 43;
+
+const ACTIVE_ORDER = {
+  recurring_order_id: RECURRING_ORDER_ID,
+  listing_id: 2,
+  account_number: '111-000-001',
+  direction: 'BUY',
+  cadence: 'WEEKLY',
+  mode: 'BY_QUANTITY',
+  value: 10,
+  active: true,
+  next_run: new Date(Date.now() + 7 * 86400000).toISOString(),
+};
+
+describe('Scenario 52: Otkazivanje trajnog naloga', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/client/*/assets', { statusCode: 200, body: { data: [], assets: [] } }).as('getPortfolio');
+    cy.intercept('GET', '**/api/recurring-orders', { statusCode: 200, body: [ACTIVE_ORDER] }).as('getRecurringOrders');
+    cy.intercept('DELETE', `**/api/recurring-orders/${RECURRING_ORDER_ID}`, { statusCode: 204, body: {} }).as('cancelOrder');
+
+    cy.loginAsClientAna();
+    cy.visit('/client/dtc');
+    cy.wait('@getPortfolio');
+    cy.wait('@getRecurringOrders');
+  });
+
+  it('otkazuje trajni nalog i uklanja ga iz liste', () => {
+    cy.intercept('GET', '**/api/recurring-orders', { statusCode: 200, body: [] }).as('getRecurringOrdersEmpty');
+
+    cy.contains('button', 'Otkaži').click();
+
+    cy.wait('@cancelOrder').its('response.statusCode').should('eq', 204);
+    cy.wait('@getRecurringOrdersEmpty');
+
+    cy.contains('Nema aktivnih trajnih naloga').should('be.visible');
+  });
+});
+
+export {};

--- a/cypress/e2e/dtc/scenario-53-actuary-used-limit-dca.cy.ts
+++ b/cypress/e2e/dtc/scenario-53-actuary-used-limit-dca.cy.ts
@@ -1,0 +1,62 @@
+/// <reference types="cypress" />
+
+// Scenario 53: Iskorišćen limit aktuara odražava izvršene DCA naloge
+// Aktuar ima limit; svaki izvršeni trajni nalog umanjuje preostali limit.
+// Supervisor proverava used_limit na stranici /admin/actuaries.
+
+const ACTUARY_ID = 7;
+
+const ACTUARY_WITH_LIMIT = {
+  id: ACTUARY_ID,
+  first_name: 'Jovana',
+  last_name: 'Jovičić',
+  email: 'jovana@bank.rs',
+  limit: 200000,
+  used_limit: 75000,
+};
+
+describe('Scenario 53: Iskorišćen limit aktuara - DCA provera', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/actuaries*', {
+      statusCode: 200,
+      body: { data: [ACTUARY_WITH_LIMIT], total: 1 },
+    }).as('getActuaries');
+
+    cy.loginAsAdmin();
+    cy.visit('/admin/actuaries');
+    cy.wait('@getActuaries');
+  });
+
+  it('prikazuje iskorišćen limit aktuara na stranici pregleda', () => {
+    cy.contains('Jovana Jovičić').should('be.visible');
+    cy.contains(/75\.000|75000/i).should('be.visible');
+  });
+
+  it('prikazuje i ukupan limit i iskorišćen limit za aktuara', () => {
+    cy.contains('Jovana Jovičić').closest('tr').within(() => {
+      cy.contains(/200\.000|200000/i).should('be.visible');
+      cy.contains(/75\.000|75000/i).should('be.visible');
+    });
+  });
+
+  it('supervisor može da resetuje iskorišćen limit aktuara', () => {
+    cy.intercept('PATCH', `**/api/actuaries/${ACTUARY_ID}/reset-used-limit`, {
+      statusCode: 200,
+      body: { ...ACTUARY_WITH_LIMIT, used_limit: 0 },
+    }).as('resetUsedLimit');
+
+    cy.intercept('GET', '**/api/actuaries*', {
+      statusCode: 200,
+      body: { data: [{ ...ACTUARY_WITH_LIMIT, used_limit: 0 }], total: 1 },
+    }).as('getActuariesAfterReset');
+
+    cy.contains('Jovana Jovičić').closest('tr').find('button').contains(/reset/i).click();
+
+    cy.contains(/resetujete iskorišćen limit/i).should('be.visible');
+    cy.contains('button', /potvrdi|da/i).click();
+
+    cy.wait('@resetUsedLimit');
+  });
+});
+
+export {};

--- a/cypress/e2e/funds/scenario-57-dividend-capital-gain-tax.cy.ts
+++ b/cypress/e2e/funds/scenario-57-dividend-capital-gain-tax.cy.ts
@@ -1,0 +1,91 @@
+/// <reference types="cypress" />
+
+// Scenario 57: Dividenda klijenta podleže porezu na kapitalnu dobit (15%)
+
+const CLIENT_ID = 100;
+const OWNERSHIP_ID = 55;
+
+const MOCK_DIVIDEND = {
+  dividendPayoutId: 1,
+  stock: 'AAPL',
+  quantity: 10,
+  grossAmount: 100.00,
+  taxAmount: 15.00,
+  netAmount: 85.00,
+  paymentDate: '2026-03-01T00:00:00Z',
+  accountNumber: '111-000-001',
+  currencyCode: 'RSD',
+};
+
+describe('Scenario 57: Dividenda podleže porezu na kapitalnu dobit', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `**/api/client/${CLIENT_ID}/assets`, {
+      statusCode: 200,
+      body: {
+        assets: [
+          {
+            ownership_id: OWNERSHIP_ID,
+            ticker: 'AAPL',
+            type: 'STOCK',
+            amount: 10,
+            public_amount: 0,
+            reserved_amount: 0,
+            price: 188.5,
+            profit: 500,
+            dividend_yield: 0.55,
+            lastModified: '2026-04-01T00:00:00Z',
+          },
+        ],
+      },
+    }).as('getPortfolio');
+
+    cy.intercept('GET', `**/api/client/${CLIENT_ID}/assets/${OWNERSHIP_ID}/dividends`, {
+      statusCode: 200,
+      body: [MOCK_DIVIDEND],
+    }).as('getDividends');
+
+    cy.window().then(win => {
+      const user = {
+        id: CLIENT_ID,
+        client_id: CLIENT_ID,
+        identity_type: 'client',
+        first_name: 'Test',
+        last_name: 'Klijent',
+      };
+      win.localStorage.setItem('user', JSON.stringify(user));
+      win.localStorage.setItem('token', 'fake-client-token');
+    });
+
+    cy.loginAsClientAna();
+    cy.visit('/client/portfolio');
+    cy.wait('@getPortfolio', { timeout: 10000 });
+  });
+
+  it('prikazuje porez od 15% u istoriji dividendi klijenta', () => {
+    cy.contains('button', 'Dividende').click();
+
+    cy.wait('@getDividends');
+
+    cy.contains(/Primljene dividende/i).should('be.visible');
+    cy.contains('AAPL').should('be.visible');
+
+    cy.contains(/15,00|15.00/i).should('be.visible');
+
+    cy.contains(/85,00|85.00/i).should('be.visible');
+  });
+
+  it('porez iznosi 15% bruto iznosa', () => {
+    cy.contains('button', 'Dividende').click();
+    cy.wait('@getDividends');
+
+    cy.get('table').within(() => {
+      cy.contains('tr', 'AAPL').within(() => {
+        cy.contains(/100/).should('exist');
+        cy.contains(/15/).should('exist');
+        cy.contains(/85/).should('exist');
+      });
+    });
+  });
+});
+
+export {};

--- a/cypress/e2e/funds/scenario-58-actuary-no-dividend-tax.cy.ts
+++ b/cypress/e2e/funds/scenario-58-actuary-no-dividend-tax.cy.ts
@@ -1,0 +1,59 @@
+/// <reference types="cypress" />
+
+// Scenario 58: Aktuar (profit banke) ne plaća porez na dividende
+// Na stranici /tax aktuar se prikazuje bez poreskog duga.
+
+const ACTUARY_TAX_ENTRY = {
+  id: 200,
+  first_name: 'Aktuar',
+  last_name: 'Bankić',
+  userType: 'actuary',
+  taxOwedRsd: 0,
+};
+
+const CLIENT_TAX_ENTRY = {
+  id: 100,
+  first_name: 'Klijent',
+  last_name: 'Porezan',
+  userType: 'client',
+  taxOwedRsd: 4500,
+};
+
+describe('Scenario 58: Aktuar ne plaća porez na dividende', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/tax*', (req) => {
+      const url = new URL(req.url);
+      const userType = url.searchParams.get('userType');
+
+      const entries = userType === 'actuary'
+        ? [ACTUARY_TAX_ENTRY]
+        : userType === 'client'
+        ? [CLIENT_TAX_ENTRY]
+        : [ACTUARY_TAX_ENTRY, CLIENT_TAX_ENTRY];
+
+      req.reply({ statusCode: 200, body: { data: entries.map(u => ({
+        ...u,
+        id: u.id,
+        first_name: u.first_name,
+        last_name: u.last_name,
+        taxOwedRsd: u.taxOwedRsd,
+      })), total: entries.length } });
+    }).as('getTax');
+
+    cy.loginAsAdmin();
+    cy.visit('/tax');
+    cy.wait('@getTax');
+  });
+
+  it('prikazuje aktuara bez poreskog duga (taxOwedRsd = 0)', () => {
+    cy.contains('Aktuar Bankić').should('be.visible');
+    cy.contains('Aktuar Bankić').closest('tr').contains(/^0|Bez duga/i).should('exist');
+  });
+
+  it('klijent ima poresku obavezu za razliku od aktuara', () => {
+    cy.contains('Klijent Porezan').should('be.visible');
+    cy.contains('Klijent Porezan').closest('tr').contains(/4[.,]500|4500/i).should('exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/funds/scenario-59-dividend-history-portfolio.cy.ts
+++ b/cypress/e2e/funds/scenario-59-dividend-history-portfolio.cy.ts
@@ -1,0 +1,92 @@
+/// <reference types="cypress" />
+
+// Scenario 59: Istorija dividendi vidljiva u portfoliju klijenta
+// Klijent otvara DividendHistoryModal klikom na "Dividende" za STOCK hartiju.
+
+const OWNERSHIP_ID = 66;
+
+const DIVIDENDS = [
+  {
+    dividendPayoutId: 10,
+    stock: 'MSFT',
+    quantity: 5,
+    grossAmount: 50.00,
+    taxAmount: 7.50,
+    netAmount: 42.50,
+    paymentDate: '2026-01-15T00:00:00Z',
+    accountNumber: '111-000-001',
+    currencyCode: 'RSD',
+  },
+  {
+    dividendPayoutId: 11,
+    stock: 'MSFT',
+    quantity: 5,
+    grossAmount: 50.00,
+    taxAmount: 7.50,
+    netAmount: 42.50,
+    paymentDate: '2026-02-15T00:00:00Z',
+    accountNumber: '111-000-001',
+    currencyCode: 'RSD',
+  },
+];
+
+describe('Scenario 59: Istorija dividendi vidljiva u portfoliju klijenta', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/client/*/assets', {
+      statusCode: 200,
+      body: {
+        assets: [
+          {
+            ownership_id: OWNERSHIP_ID,
+            ticker: 'MSFT',
+            type: 'STOCK',
+            amount: 5,
+            public_amount: 0,
+            reserved_amount: 0,
+            price: 415.0,
+            profit: 200,
+            dividend_yield: 0.75,
+            lastModified: '2026-04-01T00:00:00Z',
+          },
+        ],
+      },
+    }).as('getPortfolio');
+
+    cy.intercept('GET', `**/api/client/*/assets/${OWNERSHIP_ID}/dividends`, {
+      statusCode: 200,
+      body: DIVIDENDS,
+    }).as('getDividends');
+
+    cy.loginAsClientAna();
+    cy.visit('/client/portfolio');
+    cy.wait('@getPortfolio', { timeout: 10000 });
+  });
+
+  it('prikazuje dugme Dividende za STOCK hartije', () => {
+    cy.contains('tr', 'MSFT').contains('button', 'Dividende').should('be.visible');
+  });
+
+  it('otvara modal sa istorijom dividendi klikom na Dividende', () => {
+    cy.contains('button', 'Dividende').click();
+    cy.wait('@getDividends');
+
+    cy.contains(/Primljene dividende.*MSFT/i).should('be.visible');
+  });
+
+  it('prikazuje obe stavke dividendi u modalnom prozoru', () => {
+    cy.contains('button', 'Dividende').click();
+    cy.wait('@getDividends');
+
+    cy.get('table tbody tr').should('have.length', 2);
+  });
+
+  it('prikazuje ukupan neto iznos dividendi', () => {
+    cy.contains('button', 'Dividende').click();
+    cy.wait('@getDividends');
+
+    cy.contains(/Ukupno neto/i).should('be.visible');
+    cy.contains(/85,00|85.00/i).should('be.visible');
+  });
+});
+
+export {};

--- a/cypress/e2e/funds/scenario-75-fund-historical-chart.cy.ts
+++ b/cypress/e2e/funds/scenario-75-fund-historical-chart.cy.ts
@@ -1,0 +1,55 @@
+/// <reference types="cypress" />
+
+// Scenario 75: Grafikon istorijskih vrednosti fonda u detaljnom prikazu
+// FundDetailsPage (/client/investment-funds/:id) prikazuje LineChart sa performance_history.
+
+const FUND_ID = 1;
+
+const FUND_WITH_HISTORY = {
+  id: FUND_ID,
+  name: 'Alpha Growth Fund',
+  description: 'Fond sa prikazom istorijskog rasta.',
+  total_value: 1500000,
+  profit: 150000,
+  minimum_contribution: 10000,
+  performance_history: [
+    { date: '2025-01-01', value: 1000000 },
+    { date: '2025-04-01', value: 1100000 },
+    { date: '2025-07-01', value: 1200000 },
+    { date: '2025-10-01', value: 1350000 },
+    { date: '2026-01-01', value: 1500000 },
+  ],
+};
+
+describe('Scenario 75: Grafikon istorijskih vrednosti fonda', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `**/api/investment-funds/${FUND_ID}`, {
+      statusCode: 200,
+      body: FUND_WITH_HISTORY,
+    }).as('getFundDetails');
+
+    cy.intercept('GET', '**/api/clients/*/accounts', {
+      statusCode: 200,
+      body: { data: [] },
+    }).as('getAccounts');
+
+    cy.loginAsClientAna();
+    cy.visit(`/client/investment-funds/${FUND_ID}`);
+    cy.wait('@getFundDetails', { timeout: 10000 });
+  });
+
+  it('prikazuje naziv fonda u zaglavlju stranice', () => {
+    cy.contains('Alpha Growth Fund').should('be.visible');
+  });
+
+  it('prikazuje grafikon istorijskih vrednosti fonda', () => {
+    cy.get('canvas, svg[class*="chart"], [class*="chart"], [class*="Chart"]', { timeout: 10000 })
+      .should('exist');
+  });
+
+  it('prikazuje ukupnu vrednost i profit fonda', () => {
+    cy.contains(/1[.,]500[.,]000|1500000/i).should('be.visible');
+  });
+});
+
+export {};

--- a/cypress/e2e/funds/scenario-76-sort-by-annual-return.cy.ts
+++ b/cypress/e2e/funds/scenario-76-sort-by-annual-return.cy.ts
@@ -1,0 +1,67 @@
+/// <reference types="cypress" />
+
+// Scenario 76: Sortiranje fondova po godišnjem prinosu (annualReturn)
+// Sortiranje je client-side — FundDiscoveryPage sortira podatke iz performance_history.
+
+const HIGH_RETURN_FUND = {
+  id: 1,
+  name: 'Alpha High Return',
+  description: 'Fond sa visokim prinosom',
+  total_value: 2000000,
+  profit: 400000,
+  minimum_contribution: 10000,
+  performance_history: [
+    { date: '2025-01-01', value: 100000 },
+    { date: '2025-07-01', value: 150000 },
+    { date: '2026-01-01', value: 200000 },
+  ],
+};
+
+const LOW_RETURN_FUND = {
+  id: 2,
+  name: 'Beta Low Return',
+  description: 'Fond sa niskim prinosom',
+  total_value: 1100000,
+  profit: 50000,
+  minimum_contribution: 5000,
+  performance_history: [
+    { date: '2025-01-01', value: 100000 },
+    { date: '2025-07-01', value: 102000 },
+    { date: '2026-01-01', value: 110000 },
+  ],
+};
+
+describe('Scenario 76: Sortiranje fondova po godišnjem prinosu', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/investment-funds*', {
+      statusCode: 200,
+      body: { data: [LOW_RETURN_FUND, HIGH_RETURN_FUND], total: 2 },
+    }).as('getFunds');
+
+    cy.loginAsClient();
+    cy.visit('/investment-funds');
+    cy.wait('@getFunds', { timeout: 10000 });
+    cy.get('table', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('prikazuje kolonu Godišnji prinos u tabeli', () => {
+    cy.get('table thead').contains(/godišnji prinos/i).should('be.visible');
+  });
+
+  it('sortira fondove od najvišeg prema najnižem godišnjem prinosu klikom na header', () => {
+    cy.get('table thead').contains(/godišnji prinos/i).click();
+
+    cy.get('table tbody tr').first().contains('Alpha High Return').should('exist');
+    cy.get('table tbody tr').last().contains('Beta Low Return').should('exist');
+  });
+
+  it('invertuje sortiranje klikom drugi put — najniži prinos prvi', () => {
+    cy.get('table thead').contains(/godišnji prinos/i).click();
+    cy.get('table thead').contains(/godišnji prinos/i).click();
+
+    cy.get('table tbody tr').first().contains('Beta Low Return').should('exist');
+    cy.get('table tbody tr').last().contains('Alpha High Return').should('exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/funds/scenario-77-sort-by-max-drawdown.cy.ts
+++ b/cypress/e2e/funds/scenario-77-sort-by-max-drawdown.cy.ts
@@ -1,0 +1,68 @@
+/// <reference types="cypress" />
+
+// Scenario 77: Sortiranje fondova po maksimalnom drawdownu (Max Drawdown)
+// Veći drawdown znači veći rizik gubitka. Sortiranje je client-side.
+
+const HIGH_DRAWDOWN_FUND = {
+  id: 3,
+  name: 'Volatile Risk Fund',
+  description: 'Fond sa visokim drawdownom',
+  total_value: 800000,
+  profit: -50000,
+  minimum_contribution: 10000,
+  performance_history: [
+    { date: '2025-01-01', value: 100000 },
+    { date: '2025-04-01', value: 140000 },
+    { date: '2025-07-01', value: 70000 },
+    { date: '2026-01-01', value: 80000 },
+  ],
+};
+
+const LOW_DRAWDOWN_FUND = {
+  id: 4,
+  name: 'Stable Conservative Fund',
+  description: 'Fond sa niskim drawdownom',
+  total_value: 1200000,
+  profit: 80000,
+  minimum_contribution: 5000,
+  performance_history: [
+    { date: '2025-01-01', value: 100000 },
+    { date: '2025-07-01', value: 105000 },
+    { date: '2026-01-01', value: 110000 },
+  ],
+};
+
+describe('Scenario 77: Sortiranje fondova po maksimalnom drawdownu', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/investment-funds*', {
+      statusCode: 200,
+      body: { data: [LOW_DRAWDOWN_FUND, HIGH_DRAWDOWN_FUND], total: 2 },
+    }).as('getFunds');
+
+    cy.loginAsClient();
+    cy.visit('/investment-funds');
+    cy.wait('@getFunds', { timeout: 10000 });
+    cy.get('table', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('prikazuje kolonu Max Drawdown u tabeli', () => {
+    cy.get('table thead').contains(/max.?drawdown/i).should('be.visible');
+  });
+
+  it('sortira fondove od najvišeg prema najnižem drawdownu klikom na header', () => {
+    cy.get('table thead').contains(/max.?drawdown/i).click();
+
+    cy.get('table tbody tr').first().contains('Volatile Risk Fund').should('exist');
+    cy.get('table tbody tr').last().contains('Stable Conservative Fund').should('exist');
+  });
+
+  it('invertuje sortiranje klikom drugi put — najniži drawdown prvi', () => {
+    cy.get('table thead').contains(/max.?drawdown/i).click();
+    cy.get('table thead').contains(/max.?drawdown/i).click();
+
+    cy.get('table tbody tr').first().contains('Stable Conservative Fund').should('exist');
+    cy.get('table tbody tr').last().contains('Volatile Risk Fund').should('exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/orders/scenario-32-filter-orders-by-status.cy.ts
+++ b/cypress/e2e/orders/scenario-32-filter-orders-by-status.cy.ts
@@ -1,0 +1,84 @@
+/// <reference types="cypress" />
+
+// Scenario 32: Filtriranje istorije ordera po statusu DONE
+
+const MOCK_ORDERS = {
+  data: [
+    {
+      order_id: 201,
+      ticker: 'AAPL',
+      listing_name: 'Apple Inc.',
+      order_type: 'MARKET',
+      direction: 'BUY',
+      quantity: 10,
+      price_per_unit: 188.5,
+      status: 'DONE',
+      asset_type: 'STOCK',
+      last_modification: '2026-04-01T09:30:00Z',
+    },
+    {
+      order_id: 202,
+      ticker: 'TSLA',
+      listing_name: 'Tesla Inc.',
+      order_type: 'LIMIT',
+      direction: 'SELL',
+      quantity: 5,
+      price_per_unit: 250.0,
+      status: 'PENDING',
+      asset_type: 'STOCK',
+      last_modification: '2026-04-02T10:00:00Z',
+    },
+    {
+      order_id: 203,
+      ticker: 'MSFT',
+      listing_name: 'Microsoft',
+      order_type: 'MARKET',
+      direction: 'BUY',
+      quantity: 3,
+      price_per_unit: 415.0,
+      status: 'DONE',
+      asset_type: 'STOCK',
+      last_modification: '2026-04-03T11:00:00Z',
+    },
+  ],
+  total: 3,
+  page: 1,
+  page_size: 100,
+};
+
+describe('Scenario 32: Filtriranje istorije ordera po statusu DONE', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/orders/my*', (req) => {
+      const url = new URL(req.url);
+      const status = url.searchParams.get('status');
+      const filtered = status && status !== 'ALL'
+        ? { ...MOCK_ORDERS, data: MOCK_ORDERS.data.filter(o => o.status === status), total: MOCK_ORDERS.data.filter(o => o.status === status).length }
+        : MOCK_ORDERS;
+      req.reply({ statusCode: 200, body: filtered });
+    }).as('getMyOrders');
+
+    cy.loginAsClient();
+    cy.visit('/orders/my');
+  });
+
+  it('prikazuje sve ordere pre filtriranja', () => {
+    cy.wait('@getMyOrders');
+    cy.contains('AAPL').should('be.visible');
+    cy.contains('TSLA').should('be.visible');
+    cy.contains('MSFT').should('be.visible');
+  });
+
+  it('prikazuje samo DONE ordere kada se odabere status DONE', () => {
+    cy.wait('@getMyOrders');
+
+    cy.contains('label', 'Status').find('select').select('DONE');
+
+    cy.wait('@getMyOrders');
+
+    cy.contains('AAPL').should('be.visible');
+    cy.contains('MSFT').should('be.visible');
+    cy.contains('TSLA').should('not.exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/orders/scenario-33-filter-orders-by-date.cy.ts
+++ b/cypress/e2e/orders/scenario-33-filter-orders-by-date.cy.ts
@@ -1,0 +1,89 @@
+/// <reference types="cypress" />
+
+// Scenario 33: Filtriranje istorije ordera po opsegu datuma
+
+const ALL_ORDERS = [
+  {
+    order_id: 301,
+    ticker: 'AAPL',
+    listing_name: 'Apple Inc.',
+    order_type: 'MARKET',
+    direction: 'BUY',
+    quantity: 10,
+    price_per_unit: 188.5,
+    status: 'DONE',
+    asset_type: 'STOCK',
+    last_modification: '2026-01-15T09:00:00Z',
+  },
+  {
+    order_id: 302,
+    ticker: 'GOOG',
+    listing_name: 'Alphabet Inc.',
+    order_type: 'LIMIT',
+    direction: 'BUY',
+    quantity: 2,
+    price_per_unit: 170.0,
+    status: 'DONE',
+    asset_type: 'STOCK',
+    last_modification: '2026-03-20T10:00:00Z',
+  },
+  {
+    order_id: 303,
+    ticker: 'AMZN',
+    listing_name: 'Amazon.com',
+    order_type: 'MARKET',
+    direction: 'SELL',
+    quantity: 1,
+    price_per_unit: 200.0,
+    status: 'DONE',
+    asset_type: 'STOCK',
+    last_modification: '2026-05-10T11:00:00Z',
+  },
+];
+
+describe('Scenario 33: Filtriranje istorije ordera po opsegu datuma', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/orders/my*', (req) => {
+      const url = new URL(req.url);
+      const fromDate = url.searchParams.get('from_date');
+      const toDate = url.searchParams.get('to_date');
+
+      let filtered = ALL_ORDERS;
+      if (fromDate) {
+        const from = new Date(fromDate).getTime();
+        filtered = filtered.filter(o => new Date(o.last_modification).getTime() >= from);
+      }
+      if (toDate) {
+        const to = new Date(toDate).getTime() + 86400000;
+        filtered = filtered.filter(o => new Date(o.last_modification).getTime() <= to);
+      }
+
+      req.reply({ statusCode: 200, body: { data: filtered, total: filtered.length } });
+    }).as('getMyOrders');
+
+    cy.loginAsClient();
+    cy.visit('/orders/my');
+  });
+
+  it('prikazuje sve ordere bez filtera datuma', () => {
+    cy.wait('@getMyOrders');
+    cy.contains('AAPL').should('be.visible');
+    cy.contains('GOOG').should('be.visible');
+    cy.contains('AMZN').should('be.visible');
+  });
+
+  it('filtrira ordere po opsegu od 2026-03-01 do 2026-04-30', () => {
+    cy.wait('@getMyOrders');
+
+    cy.contains('label', 'Datum od').find('input[type="date"]').type('2026-03-01');
+    cy.contains('label', 'Datum do').find('input[type="date"]').type('2026-04-30');
+
+    cy.wait('@getMyOrders');
+
+    cy.contains('GOOG').should('be.visible');
+    cy.contains('AAPL').should('not.exist');
+    cy.contains('AMZN').should('not.exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/orders/scenario-34-filter-orders-by-type.cy.ts
+++ b/cypress/e2e/orders/scenario-34-filter-orders-by-type.cy.ts
@@ -1,0 +1,95 @@
+/// <reference types="cypress" />
+
+// Scenario 34: Filtriranje istorije ordera po tipu LIMIT
+
+const ALL_ORDERS = [
+  {
+    order_id: 401,
+    ticker: 'NVDA',
+    listing_name: 'NVIDIA Corp.',
+    order_type: 'MARKET',
+    direction: 'BUY',
+    quantity: 5,
+    price_per_unit: 800.0,
+    status: 'DONE',
+    asset_type: 'STOCK',
+    last_modification: '2026-04-01T09:00:00Z',
+  },
+  {
+    order_id: 402,
+    ticker: 'META',
+    listing_name: 'Meta Platforms',
+    order_type: 'LIMIT',
+    direction: 'BUY',
+    quantity: 3,
+    price_per_unit: 500.0,
+    status: 'DONE',
+    asset_type: 'STOCK',
+    last_modification: '2026-04-02T10:00:00Z',
+  },
+  {
+    order_id: 403,
+    ticker: 'NFLX',
+    listing_name: 'Netflix Inc.',
+    order_type: 'LIMIT',
+    direction: 'SELL',
+    quantity: 2,
+    price_per_unit: 650.0,
+    status: 'PENDING',
+    asset_type: 'STOCK',
+    last_modification: '2026-04-03T11:00:00Z',
+  },
+  {
+    order_id: 404,
+    ticker: 'DIS',
+    listing_name: 'The Walt Disney Company',
+    order_type: 'STOP',
+    direction: 'SELL',
+    quantity: 10,
+    price_per_unit: 100.0,
+    status: 'DECLINED',
+    asset_type: 'STOCK',
+    last_modification: '2026-04-04T12:00:00Z',
+  },
+];
+
+describe('Scenario 34: Filtriranje istorije ordera po tipu LIMIT', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/orders/my*', (req) => {
+      const url = new URL(req.url);
+      const orderType = url.searchParams.get('order_type');
+
+      const filtered = orderType && orderType !== 'ALL'
+        ? ALL_ORDERS.filter(o => o.order_type === orderType)
+        : ALL_ORDERS;
+
+      req.reply({ statusCode: 200, body: { data: filtered, total: filtered.length } });
+    }).as('getMyOrders');
+
+    cy.loginAsClient();
+    cy.visit('/orders/my');
+  });
+
+  it('prikazuje sve ordere pre filtriranja', () => {
+    cy.wait('@getMyOrders');
+    cy.contains('NVDA').should('be.visible');
+    cy.contains('META').should('be.visible');
+    cy.contains('NFLX').should('be.visible');
+    cy.contains('DIS').should('be.visible');
+  });
+
+  it('prikazuje samo LIMIT ordere kada se odabere tip LIMIT', () => {
+    cy.wait('@getMyOrders');
+
+    cy.contains('label', 'Tip ordera').find('select').select('LIMIT');
+
+    cy.wait('@getMyOrders');
+
+    cy.contains('META').should('be.visible');
+    cy.contains('NFLX').should('be.visible');
+    cy.contains('NVDA').should('not.exist');
+    cy.contains('DIS').should('not.exist');
+  });
+});
+
+export {};

--- a/cypress/e2e/watchlist/scenario-37-remove-from-watchlist.cy.ts
+++ b/cypress/e2e/watchlist/scenario-37-remove-from-watchlist.cy.ts
@@ -1,0 +1,55 @@
+/// <reference types="cypress" />
+
+// Scenario 37: Uklanjanje hartije sa watchliste
+// Watchlist widget je u headeru - dostupan agentima i klijentima.
+
+const WATCHLIST_ID = 10;
+const LISTING_ID   = 1;
+
+const WATCHLIST_SUMMARY = [{ id: WATCHLIST_ID, name: 'Moja lista' }];
+
+const WATCHLIST_WITH_ITEMS = {
+  id: WATCHLIST_ID,
+  name: 'Moja lista',
+  securities: [
+    { id: LISTING_ID, ticker: 'AAPL', type: 'STOCK', price: 188.5, change: 0.5, changePercent: 0.27, volume: 50000000, currency: 'USD' },
+    { id: 2, ticker: 'MSFT', type: 'STOCK', price: 415.0, change: -1.2, changePercent: -0.29, volume: 20000000, currency: 'USD' },
+  ],
+};
+
+const WATCHLIST_AFTER_REMOVE = {
+  ...WATCHLIST_WITH_ITEMS,
+  securities: [WATCHLIST_WITH_ITEMS.securities[1]],
+};
+
+describe('Scenario 37: Uklanjanje hartije sa watchliste', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/watchlists', { statusCode: 200, body: WATCHLIST_SUMMARY }).as('getWatchlists');
+    cy.intercept('GET', `**/api/watchlists/${WATCHLIST_ID}`, { statusCode: 200, body: WATCHLIST_WITH_ITEMS }).as('getWatchlistById');
+    cy.intercept('DELETE', `**/api/watchlists/${WATCHLIST_ID}/items/${LISTING_ID}`, { statusCode: 204, body: {} }).as('removeItem');
+
+    cy.loginAsClient();
+    cy.visit('/client/securities');
+    cy.wait('@getWatchlists');
+    cy.wait('@getWatchlistById');
+  });
+
+  it('briše hartiju sa watchliste i uklanja je iz prikaza', () => {
+    cy.get('button[title="Liste praćenja"]').click();
+
+    cy.contains('AAPL').should('be.visible');
+    cy.contains('MSFT').should('be.visible');
+
+    cy.intercept('GET', `**/api/watchlists/${WATCHLIST_ID}`, { statusCode: 200, body: WATCHLIST_AFTER_REMOVE }).as('getWatchlistAfterRemove');
+
+    cy.contains('tr', 'AAPL').find('button[title="Ukloni sa liste"]').click();
+
+    cy.wait('@removeItem').its('response.statusCode').should('eq', 204);
+    cy.wait('@getWatchlistAfterRemove');
+
+    cy.contains('AAPL').should('not.exist');
+    cy.contains('MSFT').should('be.visible');
+  });
+});
+
+export {};

--- a/cypress/e2e/watchlist/scenario-38-quick-order-from-watchlist.cy.ts
+++ b/cypress/e2e/watchlist/scenario-38-quick-order-from-watchlist.cy.ts
@@ -1,0 +1,42 @@
+/// <reference types="cypress" />
+
+// Scenario 38: Brzo kreiranje ordera iz watchliste
+// Klik na hartiju u watchlist widgetu navigira na /client/securities sa selectId state-om.
+
+const WATCHLIST_ID = 10;
+const LISTING_ID   = 5;
+
+const WATCHLIST_SUMMARY = [{ id: WATCHLIST_ID, name: 'Tech' }];
+
+const WATCHLIST_WITH_ITEMS = {
+  id: WATCHLIST_ID,
+  name: 'Tech',
+  securities: [
+    { id: LISTING_ID, ticker: 'NVDA', type: 'STOCK', price: 800.0, change: 10.0, changePercent: 1.27, volume: 30000000, currency: 'USD' },
+  ],
+};
+
+describe('Scenario 38: Brzo kreiranje ordera klikom na hartiju u watchlisti', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/watchlists', { statusCode: 200, body: WATCHLIST_SUMMARY }).as('getWatchlists');
+    cy.intercept('GET', `**/api/watchlists/${WATCHLIST_ID}`, { statusCode: 200, body: WATCHLIST_WITH_ITEMS }).as('getWatchlistById');
+    cy.intercept('GET', '**/api/listings/stocks*', { statusCode: 200, body: { data: [] } }).as('getStocks');
+
+    cy.loginAsClient();
+    cy.visit('/client/securities');
+    cy.wait('@getWatchlists');
+    cy.wait('@getWatchlistById');
+  });
+
+  it('navigira na stranicu hartija kada korisnik klikne na hartiju u watchlisti', () => {
+    cy.get('button[title="Liste praćenja"]').click();
+
+    cy.contains('NVDA').should('be.visible');
+
+    cy.contains('tr', 'NVDA').click();
+
+    cy.url().should('include', '/client/securities');
+  });
+});
+
+export {};

--- a/cypress/e2e/watchlist/scenario-39-filter-watchlist-by-type.cy.ts
+++ b/cypress/e2e/watchlist/scenario-39-filter-watchlist-by-type.cy.ts
@@ -1,0 +1,49 @@
+/// <reference types="cypress" />
+
+// Scenario 39: Prikaz tipa hartije u watchlisti
+// Watchlist widget prikazuje type tag pored svakog tickera.
+// Verifikujemo da su hartije različitih tipova (STOCK, FUTURES) vidljive s ispravnim tagovima.
+
+const WATCHLIST_ID = 10;
+
+const WATCHLIST_SUMMARY = [{ id: WATCHLIST_ID, name: 'Mješovita lista' }];
+
+const WATCHLIST_WITH_ITEMS = {
+  id: WATCHLIST_ID,
+  name: 'Mješovita lista',
+  securities: [
+    { id: 1, ticker: 'AAPL',  type: 'STOCK',   price: 188.5, change: 0.5,  changePercent: 0.27, volume: 50000000, currency: 'USD' },
+    { id: 2, ticker: 'ES',    type: 'FUTURES',  price: 5300.0, change: 5.0, changePercent: 0.09, volume: 1000000,  currency: 'USD' },
+    { id: 3, ticker: 'EURUSD', type: 'FOREX',   price: 1.085, change: 0.001, changePercent: 0.09, volume: 500000, currency: 'EUR' },
+  ],
+};
+
+describe('Scenario 39: Prikaz tipa hartije u watchlisti', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/watchlists', { statusCode: 200, body: WATCHLIST_SUMMARY }).as('getWatchlists');
+    cy.intercept('GET', `**/api/watchlists/${WATCHLIST_ID}`, { statusCode: 200, body: WATCHLIST_WITH_ITEMS }).as('getWatchlistById');
+
+    cy.loginAsClient();
+    cy.visit('/client/securities');
+    cy.wait('@getWatchlists');
+    cy.wait('@getWatchlistById');
+  });
+
+  it('prikazuje tip hartije (STOCK, FUTURES, FOREX) pored svakog tickera u watchlisti', () => {
+    cy.get('button[title="Liste praćenja"]').click();
+
+    cy.contains('tr', 'AAPL').contains('STOCK').should('be.visible');
+    cy.contains('tr', 'ES').contains('FUTURES').should('be.visible');
+    cy.contains('tr', 'EURUSD').contains('FOREX').should('be.visible');
+  });
+
+  it('prikazuje ispravne ticker vrednosti za sve hartije u listi', () => {
+    cy.get('button[title="Liste praćenja"]').click();
+
+    cy.contains('AAPL').should('be.visible');
+    cy.contains('ES').should('be.visible');
+    cy.contains('EURUSD').should('be.visible');
+  });
+});
+
+export {};


### PR DESCRIPTION
…75-77

- Auth (7-9): brute-force lock, locked account rejection, post-lock login
- Orders (32-34): filter by status DONE, date range, type LIMIT on /orders/my
- Watchlist (37-39): remove item, quick order navigation, type tag display
- Audit log (44-46): filter by action type, filter by user, client access denied
- DCA (51-53): pause recurring order, cancel recurring order, actuary used_limit check
- Dividends (57-59): 15% capital gain tax, actuary no tax, dividend history modal
- Fund stats (75-77): historical chart, sort by annual return, sort by max drawdown